### PR TITLE
Modifies YAML tests to be Windows compatible

### DIFF
--- a/yaml/generator_test.go
+++ b/yaml/generator_test.go
@@ -17,5 +17,5 @@ func TestJoinDockerComposeFiles(t *testing.T) {
 	require.NoError(t, err)
 	c, err := joinComposeFiles(template, add)
 	require.NoError(t, err)
-	require.Equal(t, string(want), string(c))
+	require.YAMLEq(t, string(want), string(c))
 }

--- a/yaml/testcase_test.go
+++ b/yaml/testcase_test.go
@@ -2,6 +2,7 @@ package yaml
 
 import (
 	"github.com/stretchr/testify/require"
+	"path/filepath"
 	"testing"
 )
 
@@ -28,6 +29,6 @@ func TestIncludePath(t *testing.T) {
 	AssumeNoYamlTest(t)
 
 	require.Equal(t,
-		"/home/gregor/source/grafana-opentelemetry-java/examples/jdbc/oats-non-reactive.yaml",
+		filepath.FromSlash("/home/gregor/source/grafana-opentelemetry-java/examples/jdbc/oats-non-reactive.yaml"),
 		includePath("/home/gregor/source/grafana-opentelemetry-java/examples/jdbc/spring-boot-non-reactive-2.7/oats.yaml", "../oats-non-reactive.yaml"))
 }


### PR DESCRIPTION
Modifies YAML tests to be Windows compatible. There were line ending and path separator issues.

Two changes:
1. Compares YAML structurally instead of strings
2. Run an expected file path through normalization that applies OS-specific separators 