### PR TITLE
Generic generators can include any docker-compose template file

### DIFF
--- a/yaml/generator.go
+++ b/yaml/generator.go
@@ -3,14 +3,14 @@ package yaml
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/grafana/dashboard-linter/lint"
-	"github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/grafana/dashboard-linter/lint"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 )
 
 // relative to docker-compose.yml
@@ -90,8 +90,7 @@ func (c *TestCase) getTemplateVars() (string, map[string]any) {
 	case "java":
 		return c.javaTemplateVars()
 	default:
-		ginkgo.Fail("unknown generator " + generator)
-		return "", nil
+		return filepath.FromSlash("./docker-compose-" + generator + "-template.yml"), map[string]any{}
 	}
 }
 


### PR DESCRIPTION
This allows using docker-compose-*-template.yml, where the * is replaced with the generator name.  This could be useful in substituting ports (or other config vars) in the docker compose file.  Also it allows for having multiple versions of similar things.