### PR TITLE
Allow multiple docker compose files

### DIFF
--- a/yaml/README.md
+++ b/yaml/README.md
@@ -44,7 +44,7 @@ via the environment variable `TESTCASE_BASE_PATH`.
 
 ## Docker Compose
 
-Describes the docker-compose file to use for the test.
+Describes the docker-compose file(s) to use for the test.
 The files typically defines the instrumented application you want to test and optionally some dependencies,
 e.g. a database server to send requests to.
 You don't need (and should have) to define the observability stack (e.g. prometheus, grafana, etc.),
@@ -57,8 +57,23 @@ If you're referencing other configuration files, you can use the `resources` fie
 ### Generators
 
 Generators can be used to generate a docker-compose file from a template as a way to avoid repetition.
-Currently, the only generator available is `java` which generates a docker-compose file for the java distribution
+
+Currently, the only defined generator is `java` which generates a docker-compose file for the java distribution
 examples.
+Using an undefined generator name (e.g.) `name` will result in using the file `docker-compose-name-template.yml`
+and performing template variable substitution, with the vars as seen in this excerpt of generateDockerComposeFile() in generator.go:
+```
+	vars["Dashboard"] = filepath.ToSlash(dashboard)
+	vars["ConfigDir"] = filepath.ToSlash(configDir)
+	vars["ApplicationPort"] = c.PortConfig.ApplicationPort
+	vars["GrafanaHTTPPort"] = c.PortConfig.GrafanaHTTPPort
+	vars["PrometheusHTTPPort"] = c.PortConfig.PrometheusHTTPPort
+	vars["LokiHTTPPort"] = c.PortConfig.LokiHTTPPort
+	vars["TempoHTTPPort"] = c.PortConfig.TempoHTTPPort
+```
+Additional variables could be added for more specific generators as needed. (e.g. add new case in getTemplateVars() that adds more vars.)
+
+When a generator is used, template variable interpolation will also occur on all docker-compose file(s).
 
 ## Starting the Tests
 

--- a/yaml/generator.go
+++ b/yaml/generator.go
@@ -3,14 +3,14 @@ package yaml
 import (
 	"bytes"
 	"encoding/json"
-	"github.com/grafana/dashboard-linter/lint"
-	"github.com/onsi/ginkgo/v2"
-	. "github.com/onsi/gomega"
-	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
 	"strings"
 	"text/template"
+
+	"github.com/grafana/dashboard-linter/lint"
+	. "github.com/onsi/gomega"
+	"gopkg.in/yaml.v3"
 )
 
 // relative to docker-compose.yml
@@ -90,8 +90,7 @@ func (c *TestCase) getTemplateVars() (string, map[string]any) {
 	case "java":
 		return c.javaTemplateVars()
 	default:
-		ginkgo.Fail("unknown generator " + generator)
-		return "", nil
+		return filepath.FromSlash("./docker-compose-" + generator + "-template.yml"), map[string]any{}
 	}
 }
 

--- a/yaml/generator.go
+++ b/yaml/generator.go
@@ -28,18 +28,25 @@ func (c *TestCase) getContent(compose *DockerCompose) []byte {
 	if compose.Generator != "" {
 		return c.generateDockerComposeFile()
 	} else {
-		return readComposeFile(compose)
+		// TODO: allow for template vars on docker-compose files, similar to generator
+		var buf []byte
+		for _, filename := range compose.Files {
+			var err error
+			buf, err = joinComposeFiles(buf, readComposeFile(compose, filename))
+			Expect(err).ToNot(HaveOccurred())
+		}
+		return buf
 	}
 }
 
-func readComposeFile(compose *DockerCompose) []byte {
-	b, err := os.ReadFile(compose.File)
+func readComposeFile(compose *DockerCompose, file string) []byte {
+	b, err := os.ReadFile(file)
 	Expect(err).ToNot(HaveOccurred())
 	return replaceRefs(compose, b)
 }
 
 func replaceRefs(compose *DockerCompose, bytes []byte) []byte {
-	baseDir := filepath.Dir(compose.File)
+	baseDir := filepath.Dir(compose.Files[0]) // TODO: more direct way of getting baseDir?
 	lines := strings.Split(string(bytes), "\n")
 	for i, line := range lines {
 		for _, resource := range compose.Resources {
@@ -76,12 +83,16 @@ func (c *TestCase) generateDockerComposeFile() []byte {
 	err = t.Execute(buf, vars)
 	Expect(err).ToNot(HaveOccurred())
 	compose := c.Definition.DockerCompose
-	if compose.File != "" {
-		files, err := joinComposeFiles(buf.Bytes(), readComposeFile(compose))
+	content := buf.Bytes()
+	for _, filename := range compose.Files {
+		t = template.Must(template.ParseFiles(filename))
+		addbuf := bytes.NewBufferString("")
+		err = t.Execute(addbuf, vars)
 		Expect(err).ToNot(HaveOccurred())
-		return files
+		content, err = joinComposeFiles(content, addbuf.Bytes())
+		Expect(err).ToNot(HaveOccurred())
 	}
-	return buf.Bytes()
+	return content
 }
 
 func (c *TestCase) getTemplateVars() (string, map[string]any) {

--- a/yaml/model.go
+++ b/yaml/model.go
@@ -2,13 +2,14 @@ package yaml
 
 import (
 	"fmt"
+	"path/filepath"
+	"time"
+
 	"github.com/grafana/dashboard-linter/lint"
 	"github.com/grafana/oats/internal/testhelpers/compose"
 	"github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	"gopkg.in/yaml.v3"
-	"path/filepath"
-	"time"
 )
 
 type ExpectedDashboardPanel struct {
@@ -54,7 +55,7 @@ type JavaGeneratorParams struct {
 
 type DockerCompose struct {
 	Generator           string              `yaml:"generator"`
-	File                string              `yaml:"file"`
+	Files               []string            `yaml:"files"`
 	Resources           []string            `yaml:"resources"`
 	JavaGeneratorParams JavaGeneratorParams `yaml:"java-generator-params"`
 }
@@ -201,11 +202,13 @@ func validateInput(input []Input) {
 }
 
 func validateDockerCompose(d *DockerCompose, dir string) {
-	if d.File != "" {
-		d.File = filepath.Join(dir, d.File)
-		Expect(d.File).To(BeARegularFile())
-		for _, resource := range d.Resources {
-			Expect(filepath.Join(filepath.Dir(d.File), resource)).To(BeAnExistingFile())
+	if len(d.Files) > 0 {
+		for i, filename := range d.Files {
+			d.Files[i] = filepath.Join(dir, filename)
+			Expect(d.Files[i]).To(BeARegularFile())
+			for _, resource := range d.Resources {
+				Expect(filepath.Join(filepath.Dir(d.Files[i]), resource)).To(BeAnExistingFile())
+			}
 		}
 	} else {
 		Expect(d.Generator).ToNot(BeEmpty(), "generator needed if no file is specified")


### PR DESCRIPTION
Allow specifying multiple docker-compose files.  When used with a generator, the docker-compose files will also have template variable substitution performed.  This allows for using a generic generator (e.g. docker-compose-java-template.yml minus the "application" service) to instantiate common back-end observability services.  On top of that fragments of docker-compose yaml can be added for each specific additional service (e.g. Beyla autoinstrumenter, and testserver test app.)

