### PR TITLE
accept all oats.*.yaml files

### DIFF
--- a/yaml/README.md
+++ b/yaml/README.md
@@ -2,6 +2,9 @@
 
 You can use declarative yaml tests in `oats.yaml` files:
 
+> You can use any file name that matches `oats*.yaml` (e.g. `oats-test.yaml`), that doesn't end in `-template.yaml`.
+> `oats-template.yaml` is reserved for template files, which are used in the "include" section.
+
 The syntax is a bit similar to https://github.com/kubeshop/tracetest
 
 This is an example:

--- a/yaml/testcase.go
+++ b/yaml/testcase.go
@@ -4,10 +4,13 @@ import (
 	"gopkg.in/yaml.v3"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 	"time"
 )
+
+var oatsFileRegex = regexp.MustCompile("oats.*\\.yaml")
 
 func ReadTestCases() ([]*TestCase, string) {
 	var cases []*TestCase
@@ -28,7 +31,7 @@ func ReadTestCases() ([]*TestCase, string) {
 			if err != nil {
 				return err
 			}
-			if d.Name() != "oats.yaml" {
+			if !oatsFileRegex.MatchString(d.Name()) || strings.Contains(d.Name(), "-template.yaml") {
 				return nil
 			}
 			testCase, err := readTestCase(base, p, duration)


### PR DESCRIPTION
accept all oats.*.yaml files, not only oats.yaml, but exclude files that end in -template.yaml