### PR TITLE
Docker Compose include for merging

### DIFF
--- a/yaml/docker-compose-include-base.yml
+++ b/yaml/docker-compose-include-base.yml
@@ -1,0 +1,3 @@
+include:
+{{ range .files }}- {{ . }}
+{{ end }}


### PR DESCRIPTION
Uses new docker compose include statement to merge and resolves all relative paths.

A temporary compose file is generated that references the generator, and all other defined compose files. The temporary file looks like:
```
includes:
- /full/path/to/oats/generator.yml
- /full/path/to/app/compose.yml
```

`docker compose config` is called on this temporary file, resulting in a fully rendered compose file written to the build directory. This removes the need to locally call config on compose file to resolve relative paths, and allows the usage of `include` and `extends` in all compose files.