### PR TITLE
Allow enabling global verbose logging

### DIFF
--- a/yaml/runner.go
+++ b/yaml/runner.go
@@ -19,6 +19,8 @@ type runner struct {
 	deadline time.Time
 }
 
+var VerboseLogging bool
+
 func RunTestCase(c *TestCase) {
 	r := &runner{
 		testCase: c,
@@ -137,7 +139,7 @@ func (r *runner) eventually(asserter func(g Gomega, queryLogger QueryLogger)) {
 	iterations := 0
 	Eventually(ctx, func(g Gomega) {
 		iterations++
-		verbose := false
+		verbose := VerboseLogging
 		if time.Since(t) > 10*time.Second {
 			verbose = true
 			t = time.Now()


### PR DESCRIPTION
When working on the Beyla OATS tests I had to manually enable verbose logging to see what's wrong with our tests. Since we vendor OATS in Beyla and we don't run with a checkout, it would be nice if we could enable the verbose logging on the YAML runner on demand.