### PR TITLE
Includes subdir in testcase name for better Ginkgo focus support

### DIFF
--- a/yaml/testcase.go
+++ b/yaml/testcase.go
@@ -76,7 +76,7 @@ func readTestCase(testBase, filePath string, duration time.Duration) (TestCase, 
 	}
 
 	dir := filepath.Dir(absolutePath(filePath))
-	name := strings.TrimPrefix(dir, absolutePath(testBase))
+	name := strings.TrimPrefix(dir, absolutePath(testBase)) + "-" + strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
 	sep := string(filepath.Separator)
 	name = strings.TrimPrefix(name, sep)
 	name = strings.ReplaceAll(name, sep, "-")


### PR DESCRIPTION
Includes subdir in testcase name for better --focus support

If TESTCASE_BASE_PATH is `C:\Users\mhensley\wc\grafana-opentelemetry-dotnet\docker\docker-compose-aspnetcore`
and there is a directory named `http`  with OATs YAML files

Discovered test cases will now be:
* `./http/oats.http-get.yaml` -> `http-oats.http-get`
* `./http/oats.http-geterror.yaml` -> `http-oats.http-geterror`

Previously these would have mapped as:
* `./http/oats.http-get.yaml` -> `oats.http-get`
* `./http/oats.http-geterror.yaml` -> `oats.http-geterror`

`--focus` behaves better with the directory prefix on Windows, allowing `ginkgo -r -v --focus="http"` to just run the directory of HTTP tests.