### PR TITLE
Support for Docker LGTM development

### DIFF
--- a/observability/observability_endpoint.go
+++ b/observability/observability_endpoint.go
@@ -18,4 +18,5 @@ type Endpoint interface {
 
 	Start(context.Context) error
 	Stop(context.Context) error
+	SearchComposeLogs(string) (bool, error)
 }

--- a/testhelpers/kubernetes/kubernetes.go
+++ b/testhelpers/kubernetes/kubernetes.go
@@ -7,6 +7,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"sync"
 )
 
 type Kubernetes struct {
@@ -46,7 +47,11 @@ func NewEndpoint(model *Kubernetes, ports remote.PortsConfig, logger io.WriteClo
 			}
 		}
 		return run(exec.Command("k3d", "cluster", "delete", testName), false)
-	})
+	},
+		func(f func(io.ReadCloser, *sync.WaitGroup)) error {
+			panic("not implemented for kubernetes")
+		},
+	)
 }
 
 func start(model *Kubernetes, ports remote.PortsConfig, testName string, run func(cmd *exec.Cmd, background bool) error, logger io.WriteCloser) error {

--- a/yaml/docker-compose-docker-lgtm-template.yml
+++ b/yaml/docker-compose-docker-lgtm-template.yml
@@ -1,7 +1,7 @@
 version: "3.9"
 services:
   lgtm:
-    image: grafana/otel-lgtm:latest
+    image: grafana/otel-lgtm:{{ .LgtmVersion }}
     ports:
       - "{{ .GrafanaHTTPPort }}:3000"
       - "{{ .PrometheusHTTPPort }}:9090"

--- a/yaml/generator.go
+++ b/yaml/generator.go
@@ -42,10 +42,16 @@ func (c *TestCase) generateDockerComposeFile() []byte {
 	configDir, err := filepath.Abs("configs")
 	gomega.Expect(err).ToNot(gomega.HaveOccurred())
 
-	generator := c.Definition.DockerCompose.Generator
+	compose := c.Definition.DockerCompose
+	generator := compose.Generator
 	if generator == "" {
 		generator = "docker-lgtm"
 	}
+	version := os.Getenv("LGTM_VERSION")
+	if version == "" {
+		version = "latest"
+	}
+
 	name := filepath.FromSlash("./docker-compose-" + generator + "-template.yml")
 	vars := map[string]any{}
 	vars["Dashboard"] = filepath.ToSlash(dashboard)
@@ -55,6 +61,7 @@ func (c *TestCase) generateDockerComposeFile() []byte {
 	vars["PrometheusHTTPPort"] = c.PortConfig.PrometheusHTTPPort
 	vars["LokiHTTPPort"] = c.PortConfig.LokiHTTPPort
 	vars["TempoHTTPPort"] = c.PortConfig.TempoHTTPPort
+	vars["LgtmVersion"] = version
 
 	env := os.Environ()
 
@@ -62,7 +69,7 @@ func (c *TestCase) generateDockerComposeFile() []byte {
 		env = append(env, fmt.Sprintf("%s=%s", k, v))
 	}
 
-	env = append(env, c.Definition.DockerCompose.Environment...)
+	env = append(env, compose.Environment...)
 
 	t := template.Must(template.ParseFiles(name))
 
@@ -75,7 +82,6 @@ func (c *TestCase) generateDockerComposeFile() []byte {
 	defer func(name string) {
 		_ = os.Remove(name)
 	}(generated)
-	compose := c.Definition.DockerCompose
 	files := []string{generated}
 	for _, filename := range compose.Files {
 		t = template.Must(template.ParseFiles(filename))

--- a/yaml/generator.go
+++ b/yaml/generator.go
@@ -51,6 +51,7 @@ func (c *TestCase) generateDockerComposeFile() []byte {
 	if version == "" {
 		version = "latest"
 	}
+	println("using docker-compose generator", generator, "version", version)
 
 	name := filepath.FromSlash("./docker-compose-" + generator + "-template.yml")
 	vars := map[string]any{}

--- a/yaml/model.go
+++ b/yaml/model.go
@@ -56,6 +56,7 @@ type CustomCheck struct {
 }
 
 type Expected struct {
+	ComposeLogs  []string            `yaml:"compose-logs"`
 	Logs         []ExpectedLogs      `yaml:"logs"`
 	Traces       []ExpectedTraces    `yaml:"traces"`
 	Metrics      []ExpectedMetrics   `yaml:"metrics"`

--- a/yaml/runner.go
+++ b/yaml/runner.go
@@ -73,6 +73,16 @@ func RunTestCase(c *TestCase) {
 	})
 
 	expected := c.Definition.Expected
+	for _, composeLog := range expected.ComposeLogs {
+		ginkgo.It(fmt.Sprintf("should have '%s' in internal compose logs", composeLog), func() {
+			r.eventually(func() {
+				found, err := r.endpoint.SearchComposeLogs(composeLog)
+				r.gomegaInst.Expect(err).ToNot(gomega.HaveOccurred())
+				r.gomegaInst.Expect(found).To(gomega.BeTrue())
+			})
+		})
+	}
+
 	// Assert logs traces first, because metrics and dashboards can take longer to appear
 	// (depending on OTEL_METRIC_EXPORT_INTERVAL).
 	for _, log := range expected.Logs {


### PR DESCRIPTION
- set the LGTM version explicitly with `LGTM_VERSION`
- search in compose logs (for health check) with `compose-logs:`

See it all in action: https://github.com/grafana/docker-otel-lgtm/pull/367