### PR TITLE
Support yml files for test cases

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 .idea/
 **/*.log
 build/
+oats.exe

--- a/yaml/testcase.go
+++ b/yaml/testcase.go
@@ -3,12 +3,13 @@ package yaml
 import (
 	"errors"
 	"fmt"
-	"gopkg.in/yaml.v3"
 	"log/slog"
 	"os"
 	"path/filepath"
 	"regexp"
 	"strings"
+
+	"gopkg.in/yaml.v3"
 )
 
 var oatsFileRegex = regexp.MustCompile(`oats.*\.yaml`)

--- a/yaml/testcase.go
+++ b/yaml/testcase.go
@@ -12,7 +12,7 @@ import (
 	"gopkg.in/yaml.v3"
 )
 
-var oatsFileRegex = regexp.MustCompile(`oats.*\.yaml`)
+var oatsFileRegex = regexp.MustCompile(`oats.*\.ya?ml`)
 
 func ReadTestCases(base string) ([]*TestCase, string) {
 	if base == "" {

--- a/yaml/testcase_test.go
+++ b/yaml/testcase_test.go
@@ -1,9 +1,10 @@
 package yaml
 
 import (
-	"github.com/stretchr/testify/require"
 	"path/filepath"
 	"testing"
+
+	"github.com/stretchr/testify/require"
 )
 
 func TestReadTestCaseDefinition(t *testing.T) {

--- a/yaml/testcase_test.go
+++ b/yaml/testcase_test.go
@@ -31,7 +31,8 @@ func TestIncludePath(t *testing.T) {
 func TestCollectTestCases(t *testing.T) {
 	cases, err := collectTestCases("testdata", false)
 	require.NoError(t, err)
-	require.Len(t, cases, 2)
-	require.Equal(t, "runfoo-oats", cases[0].Name)
-	require.Equal(t, "run-oats-merged", cases[1].Name)
+	require.Len(t, cases, 3)
+	require.Equal(t, "runfoo-more-oats", cases[0].Name)
+	require.Equal(t, "runfoo-oats", cases[1].Name)
+	require.Equal(t, "run-oats-merged", cases[2].Name)
 }

--- a/yaml/testdata/foo/more-oats.yml
+++ b/yaml/testdata/foo/more-oats.yml
@@ -1,0 +1,7 @@
+include:
+  - ../oats-template.yaml
+expected:
+  logs:
+    - logql: '{ service_name="foo" } |~ `Application started.`'
+      contains:
+        - 'Application started'


### PR DESCRIPTION
- Support OATS test case files having a `.yml` extension.
- Commit formatting changes when saving files in Visual Studio Code.
- Ignore binary file generated when running `go build` on Windows from the root of the repo.
