### PR TITLE
Support non-GET requests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,4 @@
 .idea/
 **/*.log
 build/
-oats.exe
+*.exe

--- a/README.md
+++ b/README.md
@@ -29,6 +29,7 @@ oats
 
 ## Getting Started
 
+> [!TIP]
 > You can use the test cases in [prom_client_java](https://github.com/prometheus/client_java/tree/main/examples/example-exporter-opentelemetry/oats-tests) as a reference.
 > The [GitHub action](https://github.com/prometheus/client_java/blob/main/.github/workflows/acceptance-tests.yml)
 > uses a [script](https://github.com/prometheus/client_java/blob/main/scripts/run-acceptance-tests.sh) to run the tests.

--- a/main.go
+++ b/main.go
@@ -4,10 +4,11 @@ import (
 	"errors"
 	"flag"
 	"fmt"
-	"github.com/grafana/oats/yaml"
-	"github.com/onsi/gomega"
 	"log/slog"
 	"time"
+
+	"github.com/grafana/oats/yaml"
+	"github.com/onsi/gomega"
 )
 
 func main() {
@@ -18,6 +19,7 @@ func main() {
 }
 
 func run() error {
+	host := flag.String("host", "localhost", "host to run the test case against")
 	lgtmVersion := flag.String("lgtm-version", "latest", "version of https://github.com/grafana/docker-otel-lgtm")
 
 	logAll := flag.Bool("lgtm-log-all", false, "enable logging for all LGTM components")
@@ -58,6 +60,7 @@ func run() error {
 	}
 
 	for _, c := range cases {
+		c.Host = *host
 		c.LgtmVersion = *lgtmVersion
 		c.LgtmLogSettings = logSettings
 		c.Timeout = *timeout

--- a/main.go
+++ b/main.go
@@ -19,7 +19,7 @@ func main() {
 }
 
 func run() error {
-	host := flag.String("host", "localhost", "host to run the test case against")
+	host := flag.String("host", "localhost", "host to run the test cases against")
 	lgtmVersion := flag.String("lgtm-version", "latest", "version of https://github.com/grafana/docker-otel-lgtm")
 
 	logAll := flag.Bool("lgtm-log-all", false, "enable logging for all LGTM components")

--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"flag"
 	"fmt"
 	"log/slog"
+	"slices"
 	"time"
 
 	"github.com/grafana/oats/yaml"
@@ -52,6 +53,16 @@ func run() error {
 	})
 
 	cases, base := yaml.ReadTestCases(flag.Arg(0))
+
+	// Filter out all test cases that don't have a Kubernetes or Compose section, as that probably
+	// means we found unrelated YAML files in the directory that happen to end in ".oats.y{a}ml".
+	for i := len(cases) - 1; i >= 0; i-- {
+		testcase := cases[i]
+		if testcase.Definition.DockerCompose == nil && testcase.Definition.Kubernetes == nil {
+			cases = slices.Delete(cases, i, i+1)
+		}
+	}
+
 	if len(cases) == 0 {
 		return fmt.Errorf("no cases found in %s", base)
 	}

--- a/testhelpers/compose/compose.go
+++ b/testhelpers/compose/compose.go
@@ -6,7 +6,6 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/grafana/oats/testhelpers/remote"
 	"io"
 	"log/slog"
 	"os"
@@ -14,6 +13,8 @@ import (
 	"path"
 	"strings"
 	"sync"
+
+	"github.com/grafana/oats/testhelpers/remote"
 )
 
 type Compose struct {
@@ -132,9 +133,9 @@ func (c *Compose) Close() error {
 	return errors.New(strings.Join(errs, " / "))
 }
 
-func NewEndpoint(composeFilePath string, ports remote.PortsConfig) *remote.Endpoint {
+func NewEndpoint(host string, composeFilePath string, ports remote.PortsConfig) *remote.Endpoint {
 	var compose *Compose
-	return remote.NewEndpoint(ports, func(ctx context.Context) error {
+	return remote.NewEndpoint(host, ports, func(ctx context.Context) error {
 		var err error
 
 		if composeFilePath == "" {

--- a/testhelpers/kubernetes/kubernetes.go
+++ b/testhelpers/kubernetes/kubernetes.go
@@ -3,12 +3,13 @@ package kubernetes
 import (
 	"context"
 	"fmt"
-	"github.com/grafana/oats/testhelpers/remote"
 	"io"
 	"log/slog"
 	"os"
 	"os/exec"
 	"sync"
+
+	"github.com/grafana/oats/testhelpers/remote"
 )
 
 type Kubernetes struct {
@@ -21,7 +22,7 @@ type Kubernetes struct {
 	ImportImages     []string `yaml:"import-images"`
 }
 
-func NewEndpoint(model *Kubernetes, ports remote.PortsConfig, testName string, dir string) *remote.Endpoint {
+func NewEndpoint(host string, model *Kubernetes, ports remote.PortsConfig, testName string, dir string) *remote.Endpoint {
 	var killList []*os.Process
 	run := func(cmd *exec.Cmd, background bool) error {
 		slog.Info("running", "command", cmd.String(), "dir", dir)
@@ -38,7 +39,7 @@ func NewEndpoint(model *Kubernetes, ports remote.PortsConfig, testName string, d
 		}
 		return cmd.Run()
 	}
-	return remote.NewEndpoint(ports, func(ctx context.Context) error {
+	return remote.NewEndpoint(host, ports, func(ctx context.Context) error {
 		return start(model, ports, testName, run)
 	}, func(ctx context.Context) error {
 		for _, p := range killList {

--- a/testhelpers/requests/http.go
+++ b/testhelpers/requests/http.go
@@ -3,7 +3,9 @@ package requests
 import (
 	"crypto/tls"
 	"fmt"
+	"io"
 	"net/http"
+	"strings"
 )
 
 var tr = &http.Transport{
@@ -12,8 +14,6 @@ var tr = &http.Transport{
 var testHTTPClient = &http.Client{Transport: tr}
 
 func doRequest(req *http.Request, statusCode int) error {
-	req.Header.Set("Content-Type", "application/json")
-
 	r, err := testHTTPClient.Do(req)
 
 	if err != nil {
@@ -27,11 +27,21 @@ func doRequest(req *http.Request, statusCode int) error {
 	return nil
 }
 
-func DoHTTPGet(url string, statusCode int) error {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+func DoHTTPRequest(url string, method string, headers map[string]string, payload string, statusCode int) error {
+	var body io.Reader = nil
+
+	if payload != "" {
+		body = strings.NewReader(payload)
+	}
+
+	req, err := http.NewRequest(method, url, body)
 
 	if err != nil {
 		return err
+	}
+
+	for k, v := range headers {
+		req.Header.Set(k, v)
 	}
 
 	return doRequest(req, statusCode)

--- a/yaml/model.go
+++ b/yaml/model.go
@@ -80,6 +80,8 @@ type DockerCompose struct {
 }
 
 type Input struct {
+	Scheme  string            `yaml:"scheme"`
+	Host    string            `yaml:"host"`
 	Method  string            `yaml:"method"`
 	Path    string            `yaml:"path"`
 	Headers map[string]string `yaml:"headers"`
@@ -240,6 +242,12 @@ func validateInput(input []Input) {
 		}
 		if (i.Method == "" || i.Method == http.MethodGet) && i.Body != "" {
 			gomega.Expect(i.Body).To(gomega.BeEmpty(), "body must be empty for GET requests")
+		}
+		if i.Scheme != "" {
+			gomega.Expect(strings.ToLower(i.Scheme)).To(gomega.Or(
+				gomega.Equal("http"),
+				gomega.Equal("https"),
+			), "scheme must be http, https or be empty")
 		}
 	}
 }

--- a/yaml/model.go
+++ b/yaml/model.go
@@ -127,6 +127,7 @@ type TestCase struct {
 	Name               string
 	MatrixTestCaseName string
 	Dir                string
+	Host               string
 	OutputDir          string
 	Definition         TestCaseDefinition
 	PortConfig         *PortConfig

--- a/yaml/model.go
+++ b/yaml/model.go
@@ -10,7 +10,6 @@ import (
 	"time"
 
 	"github.com/grafana/oats/testhelpers/kubernetes"
-
 	"github.com/onsi/gomega"
 	"gopkg.in/yaml.v3"
 )

--- a/yaml/model_test.go
+++ b/yaml/model_test.go
@@ -1,0 +1,18 @@
+package yaml
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTestCasesAreValid(t *testing.T) {
+	cases, err := collectTestCases("testdata", false)
+	require.NoError(t, err)
+	require.NotEmpty(t, cases)
+	for _, c := range cases {
+		require.NotEqual(t, nil, c.Definition)
+		require.NotEmpty(t, c.Definition.Input)
+		validateInput(c.Definition.Input)
+	}
+}

--- a/yaml/runner.go
+++ b/yaml/runner.go
@@ -28,6 +28,7 @@ type runner struct {
 	testCase          *TestCase
 	endpoint          *remote.Endpoint
 	deadline          time.Time
+	host              string
 	Verbose           bool
 	gomegaInst        gomega.Gomega
 	additionalAsserts []func()
@@ -38,6 +39,7 @@ var VerboseLogging bool
 func RunTestCase(c *TestCase) {
 	format.MaxLength = 100000
 	r := &runner{
+		host:     c.Host,
 		testCase: c,
 	}
 
@@ -148,9 +150,9 @@ func startEndpoint(c *TestCase) (*remote.Endpoint, error) {
 	slog.Info("start test", "name", c.Name)
 	var endpoint *remote.Endpoint
 	if c.Definition.Kubernetes != nil {
-		endpoint = kubernetes.NewEndpoint(c.Definition.Kubernetes, ports, c.Name, c.Dir)
+		endpoint = kubernetes.NewEndpoint(c.Host, c.Definition.Kubernetes, ports, c.Name, c.Dir)
 	} else {
-		endpoint = compose.NewEndpoint(c.CreateDockerComposeFile(), ports)
+		endpoint = compose.NewEndpoint(c.Host, c.CreateDockerComposeFile(), ports)
 	}
 
 	var ctx = context.Background()
@@ -199,7 +201,7 @@ func (r *runner) eventually(asserter func()) {
 			if i.Scheme != "" {
 				scheme = i.Scheme
 			}
-			host := "localhost"
+			host := r.host
 			if i.Host != "" {
 				host = i.Host
 			}

--- a/yaml/runner.go
+++ b/yaml/runner.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"maps"
 	"net/http"
 	"os"
 	"os/exec"
@@ -13,15 +14,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/oats/testhelpers/compose"
 	"github.com/grafana/oats/testhelpers/kubernetes"
 	"github.com/grafana/oats/testhelpers/remote"
-	"github.com/onsi/gomega/format"
-
-	"maps"
-
-	"github.com/grafana/oats/testhelpers/compose"
 	"github.com/grafana/oats/testhelpers/requests"
 	"github.com/onsi/gomega"
+	"github.com/onsi/gomega/format"
 )
 
 type runner struct {

--- a/yaml/runner.go
+++ b/yaml/runner.go
@@ -51,7 +51,7 @@ func RunTestCase(c *TestCase) {
 	r.deadline = time.Now().Add(c.Timeout)
 	r.endpoint = endpoint
 	if c.ManualDebug {
-		slog.Info(fmt.Sprintf("topping to let you manually debug on http://localhost:%d\n", r.testCase.PortConfig.GrafanaHTTPPort))
+		slog.Info(fmt.Sprintf("stopping to let you manually debug on http://%s:%d\n", r.host, r.testCase.PortConfig.GrafanaHTTPPort))
 
 		for {
 			r.eventually(func() {

--- a/yaml/runner.go
+++ b/yaml/runner.go
@@ -195,7 +195,15 @@ func (r *runner) eventually(asserter func()) {
 		r.LogQueryResult("waiting for telemetry data\n")
 
 		for _, i := range r.testCase.Definition.Input {
-			url := fmt.Sprintf("http://localhost:%d%s", r.testCase.PortConfig.ApplicationPort, i.Path)
+			scheme := "http"
+			if i.Scheme != "" {
+				scheme = i.Scheme
+			}
+			host := "localhost"
+			if i.Host != "" {
+				host = i.Host
+			}
+			url := fmt.Sprintf("%s://%s:%d%s", scheme, host, r.testCase.PortConfig.ApplicationPort, i.Path)
 			body := i.Body
 			method := http.MethodGet
 			if i.Method != "" {

--- a/yaml/testcase.go
+++ b/yaml/testcase.go
@@ -50,7 +50,7 @@ func collectTestCases(base string, evaluateIgnoreFile bool) ([]*TestCase, error)
 			}
 		}
 
-		if !oatsFileRegex.MatchString(d.Name()) || strings.Contains(d.Name(), "-template.yaml") {
+		if !oatsFileRegex.MatchString(d.Name()) || strings.Contains(d.Name(), "-template.yaml") || strings.Contains(d.Name(), "-template.yml") {
 			return nil
 		}
 

--- a/yaml/testcase.go
+++ b/yaml/testcase.go
@@ -96,13 +96,15 @@ func readTestCase(testBase, filePath string) (TestCase, error) {
 		return TestCase{}, err
 	}
 
-	dir := filepath.Dir(absolutePath(filePath))
+	absoluteFilePath := absolutePath(filePath)
+	dir := filepath.Dir(absoluteFilePath)
 	name := strings.TrimPrefix(dir, absolutePath(testBase)) + "-" + strings.TrimSuffix(filepath.Base(filePath), filepath.Ext(filePath))
 	sep := string(filepath.Separator)
 	name = strings.TrimPrefix(name, sep)
 	name = strings.ReplaceAll(name, sep, "-")
 	name = "run" + name
 	testCase := TestCase{
+		Path:       absoluteFilePath,
 		Name:       name,
 		Dir:        dir,
 		Definition: def,

--- a/yaml/testcase_test.go
+++ b/yaml/testcase_test.go
@@ -28,11 +28,45 @@ func TestIncludePath(t *testing.T) {
 		includePath("/home/gregor/source/grafana-opentelemetry-java/examples/jdbc/spring-boot-non-reactive-2.7/oats.yaml", "../oats-non-reactive.yaml"))
 }
 
+func TestInputDefinitionsAreCorrect(t *testing.T) {
+	def, err := readTestCaseDefinition("testdata/foo/input.oats.yaml")
+	require.NoError(t, err)
+	require.Len(t, def.Input, 3)
+	item := def.Input[0]
+	require.Equal(t, "/stock", item.Path)
+	require.Equal(t, "", item.Scheme)
+	require.Equal(t, "", item.Host)
+	require.Equal(t, "", item.Method)
+	require.Empty(t, item.Headers)
+	require.Equal(t, "", item.Body)
+	require.Equal(t, "", item.Status)
+	item = def.Input[1]
+	require.Equal(t, "/buy", item.Path)
+	require.Equal(t, "", item.Scheme)
+	require.Equal(t, "", item.Host)
+	require.Equal(t, "POST", item.Method)
+	require.Len(t, item.Headers, 2)
+	require.Equal(t, "Bearer user-token", item.Headers["Authorization"])
+	require.Equal(t, "application/json", item.Headers["Content-Type"])
+	require.Equal(t, "{\"id\": \"42\", \"quantity\": 10}", item.Body)
+	require.Equal(t, "201", item.Status)
+	item = def.Input[2]
+	require.Equal(t, "/delist/42", item.Path)
+	require.Equal(t, "https", item.Scheme)
+	require.Equal(t, "127.0.0.1", item.Host)
+	require.Equal(t, "DELETE", item.Method)
+	require.Len(t, item.Headers, 1)
+	require.Equal(t, "Bearer admin-token", item.Headers["Authorization"])
+	require.Equal(t, "", item.Body)
+	require.Equal(t, "204", item.Status)
+}
+
 func TestCollectTestCases(t *testing.T) {
 	cases, err := collectTestCases("testdata", false)
 	require.NoError(t, err)
-	require.Len(t, cases, 3)
-	require.Equal(t, "runfoo-more-oats", cases[0].Name)
-	require.Equal(t, "runfoo-oats", cases[1].Name)
-	require.Equal(t, "run-oats-merged", cases[2].Name)
+	require.Len(t, cases, 4)
+	require.Equal(t, "runfoo-input.oats", cases[0].Name)
+	require.Equal(t, "runfoo-more-oats", cases[1].Name)
+	require.Equal(t, "runfoo-oats", cases[2].Name)
+	require.Equal(t, "run-oats-merged", cases[3].Name)
 }

--- a/yaml/testdata/foo/input.oats.yaml
+++ b/yaml/testdata/foo/input.oats.yaml
@@ -1,0 +1,21 @@
+docker-compose:
+input:
+  - path: /stock
+  - path: /buy
+    method: POST
+    headers:
+      Authorization: Bearer user-token
+      Content-Type: application/json
+    body: '{"id": "42", "quantity": 10}'
+    status: 201
+  - path: /delist/42
+    method: DELETE
+    scheme: https
+    host: 127.0.0.1
+    headers:
+      Authorization: Bearer admin-token
+    status: 204
+expected:
+  metrics:
+    - promql: bar
+      value: '>= 0'

--- a/yaml/testdata/oats-merged.yaml
+++ b/yaml/testdata/oats-merged.yaml
@@ -2,6 +2,18 @@ docker-compose:
 input:
   - path: /stock
     status: 200
+  - path: /buy
+    method: POST
+    headers:
+      Authorization: Bearer user-token
+      Content-Type: application/json
+    body: '{"id": "42", "quantity": 10}'
+    status: 201
+  - path: /delist/42
+    method: DELETE
+    headers:
+      Authorization: Bearer admin-token
+    status: 204
 expected:
   traces:
     - traceql: '{ name =~ "SELECT .*cart"}'

--- a/yaml/testdata/oats-template.yaml
+++ b/yaml/testdata/oats-template.yaml
@@ -2,6 +2,18 @@ docker-compose:
 input:
   - path: /stock
     status: 200
+  - path: /buy
+    method: POST
+    headers:
+      Authorization: Bearer user-token
+      Content-Type: application/json
+    body: '{"id": "42", "quantity": 10}'
+    status: 201
+  - path: /delist/42
+    method: DELETE
+    headers:
+      Authorization: Bearer admin-token
+    status: 204
 expected:
   traces:
     - traceql: '{ name =~ "SELECT .*product"}'


### PR DESCRIPTION
Makes a number of improvements after dogfooding with one of my own personal applications:

- Allow `localhost` to be overridden by new `--host` flag. This is mainly to combat the fact that on my laptop Docker randomly decides to stop working on `localhost` but `127.0.0.1` still works.
- Add support for configuring custom values for the inputs for:
  - The scheme (only `http` and `https` are supported)
  - The host (instead of `localhost` or the value specified by `--host`)
  - The method (instead of always being `GET`)
  - Any custom HTTP request headers (instead of just `Content-Type: application/json`)
  - A body (e.g. to `POST` some JSON)
- Adjusts some `gomega` assertions to improve the failure messages
- Fixes a typo in the message when manually debugging
- Fixes a missing change from #133 to ignore `-template.yml` files

Also tidies up some formatting that Visual Studio Code kept changing while I was working. Doesn't seem entirely consistent though - is there some configuration missing somewhere to tell `go fmt` what rules to apply?

### TODO

- [x] Manual testing with the app where I wanted to do this - tested with https://github.com/martincostello/costellobot/pull/2493
- [x] More unit tests
- [x] Update documentation
