### PR TITLE
Specify delay/interval values

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ oats
           OTEL_SERVICE_NAME: "rolldice"
           OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
           OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
-          OTEL_METRIC_EXPORT_INTERVAL: "5000"  # so we don't have to wait 60s for metrics
     ```
 4. Create `oats.yaml` with the test cases
     ```yaml

--- a/yaml/generator.go
+++ b/yaml/generator.go
@@ -47,6 +47,12 @@ func (c *TestCase) generateDockerComposeFile() []byte {
 	vars["LgtmVersion"] = c.LgtmVersion
 	vars["LgtmLogSettings"] = c.LgtmLogSettings
 
+	// TODO Make configurable/opt-out?
+	// Overrides to make tests faster by exporting data more frequently
+	vars["OTEL_BLRP_SCHEDULE_DELAY"] = "5000"
+	vars["OTEL_BSP_SCHEDULE_DELAY"] = "5000"
+	vars["OTEL_METRIC_EXPORT_INTERVAL"] = "5000"
+
 	env := os.Environ()
 
 	for k, v := range vars {

--- a/yaml/generator.go
+++ b/yaml/generator.go
@@ -47,8 +47,7 @@ func (c *TestCase) generateDockerComposeFile() []byte {
 	vars["LgtmVersion"] = c.LgtmVersion
 	vars["LgtmLogSettings"] = c.LgtmLogSettings
 
-	// TODO Make configurable/opt-out?
-	// Overrides to make tests faster by exporting data more frequently
+	// Overrides to make tests faster by exporting telemetry data more frequently
 	vars["OTEL_BLRP_SCHEDULE_DELAY"] = "5000"
 	vars["OTEL_BSP_SCHEDULE_DELAY"] = "5000"
 	vars["OTEL_METRIC_EXPORT_INTERVAL"] = "5000"


### PR DESCRIPTION
Explicitly state the delay and intervals for telemetry publishing by default to speed up test cases.

Inspired by https://github.com/grafana/grafana-opentelemetry-dotnet/pull/198.