### PR TITLE
chore: fix flint baseline lint failures

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -1,28 +1,18 @@
 {
   ".github/renovate.json5": {
-    "renovate-config-presets": [
-      "grafana/flint"
-    ]
+    "renovate-config-presets": ["grafana/flint"]
   },
   ".github/workflows/build.yml": {
-    "regex": [
-      "mise"
-    ]
+    "regex": ["mise"]
   },
   ".github/workflows/e2e_test.yml": {
-    "regex": [
-      "mise"
-    ]
+    "regex": ["mise"]
   },
   ".github/workflows/integration_test.yml": {
-    "regex": [
-      "mise"
-    ]
+    "regex": ["mise"]
   },
   ".github/workflows/lint.yml": {
-    "regex": [
-      "mise"
-    ]
+    "regex": ["mise"]
   },
   "go.mod": {
     "gomod": [
@@ -85,19 +75,12 @@
     ]
   },
   "yaml/testdata/docker-compose-addition.yaml": {
-    "docker-compose": [
-      "mongo"
-    ]
+    "docker-compose": ["mongo"]
   },
   "yaml/testdata/docker-compose-expected.yaml": {
-    "docker-compose": [
-      "grafana/grafana",
-      "mongo"
-    ]
+    "docker-compose": ["grafana/grafana", "mongo"]
   },
   "yaml/testdata/docker-compose-template.yaml": {
-    "docker-compose": [
-      "grafana/grafana"
-    ]
+    "docker-compose": ["grafana/grafana"]
   }
 }

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,2 @@
+yaml/docker-compose-docker-lgtm-template.yml
+yaml/testdata/invalid-tests/malformed-yaml.yaml

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ OpenTelemetry Acceptance Tests (OATs), or OATs for short, is a test framework fo
 go install github.com/grafana/oats@latest
 ```
 
-2. You can confirm it was installed with:
+1. You can confirm it was installed with:
 
 ```sh
 ❯ ls $GOPATH/bin
@@ -35,13 +35,16 @@ oats
 > uses `mise run acceptance-test` to run the tests.
 
 1. Create a folder `oats-tests` for the following files
-2. Create `Dockerfile` to build the application you want to test
+1. Create `Dockerfile` to build the application you want to test
+
    ```Dockerfile
    FROM eclipse-temurin:21-jre
    COPY target/example-exporter-opentelemetry.jar ./app.jar
    ENTRYPOINT [ "java", "-jar", "./app.jar" ]
    ```
-3. Create `docker-compose.yaml` to start the application and any dependencies
+
+1. Create `docker-compose.yaml` to start the application and any dependencies
+
    ```yaml
    services:
      java:
@@ -52,7 +55,9 @@ oats
          OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4318
          OTEL_EXPORTER_OTLP_PROTOCOL: http/protobuf
    ```
-4. Create `oats.yaml` with the test cases
+
+1. Create `oats.yaml` with the test cases
+
    ```yaml
    # OATs is an acceptance testing framework for OpenTelemetry - https://github.com/grafana/oats
    oats-schema-version: 2
@@ -64,7 +69,8 @@ oats
        - promql: "uptime_seconds_total{}"
          value: ">= 0"
    ```
-5. Run the tests:
+
+1. Run the tests:
 
 ```sh
 oats /path/to/oats-tests/oats.yaml

--- a/yaml/testdata/docker-compose-addition.yaml
+++ b/yaml/testdata/docker-compose-addition.yaml
@@ -1,4 +1,4 @@
-version: '3.9'
+version: "3.9"
 
 x-default-logging: &logging
   driver: "json-file"
@@ -10,7 +10,7 @@ services:
   mongodb:
     image: mongo:7-jammy
     ports:
-      - '27017:27017'
+      - "27017:27017"
     volumes:
       - dbdata6:/data/db
     logging: *logging

--- a/yaml/testdata/docker-compose-expected.yaml
+++ b/yaml/testdata/docker-compose-expected.yaml
@@ -1,31 +1,31 @@
 networks:
-    default:
-        driver: bridge
-        ipam:
-            config:
-                - subnet: 172.16.57.0/24
+  default:
+    driver: bridge
+    ipam:
+      config:
+        - subnet: 172.16.57.0/24
 services:
-    grafana:
-        image: grafana/grafana:13.0.1@sha256:0f86bada30d65ef9d0183b90c1e2682ac92d53d95da8bed322b984ea78a4a73a
-        network_mode: host
-        volumes:
-            - ./configs/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/grafana-datasources.yaml
-    mongodb:
-        image: mongo:7-jammy
-        logging:
-            driver: json-file
-            options:
-                max-file: "2"
-                max-size: 5m
-        ports:
-            - 27017:27017
-        volumes:
-            - dbdata6:/data/db
-version: "3.9"
-volumes:
-    dbdata6: null
-x-default-logging:
-    driver: json-file
-    options:
+  grafana:
+    image: grafana/grafana:13.0.1@sha256:0f86bada30d65ef9d0183b90c1e2682ac92d53d95da8bed322b984ea78a4a73a
+    network_mode: host
+    volumes:
+      - ./configs/grafana-datasources.yaml:/etc/grafana/provisioning/datasources/grafana-datasources.yaml
+  mongodb:
+    image: mongo:7-jammy
+    logging:
+      driver: json-file
+      options:
         max-file: "2"
         max-size: 5m
+    ports:
+      - 27017:27017
+    volumes:
+      - dbdata6:/data/db
+version: "3.9"
+volumes:
+  dbdata6: null
+x-default-logging:
+  driver: json-file
+  options:
+    max-file: "2"
+    max-size: 5m

--- a/yaml/testdata/invalid-tests/outdated-version.yaml
+++ b/yaml/testdata/invalid-tests/outdated-version.yaml
@@ -3,8 +3,7 @@ expected:
   traces:
     - traceql: '{ name =~ "SELECT .*cart"}'
       spans:
-        - contains: 'outdated oats test'
+        - contains: "outdated oats test"
   metrics:
     - promql: foo
-      value: '>= 0'
-
+      value: ">= 0"

--- a/yaml/testdata/invalid-tests/unknown-field.yaml
+++ b/yaml/testdata/invalid-tests/unknown-field.yaml
@@ -3,8 +3,7 @@ expected:
   traces:
     - traceql: '{ name =~ "SELECT .*cart"}'
       spans:
-        - contains: 'outdated oats test'
+        - contains: "outdated oats test"
   metrics:
     - promql: foo
-      value: '>= 0'
-
+      value: ">= 0"

--- a/yaml/testdata/invalid-tests/version-not-int.yaml
+++ b/yaml/testdata/invalid-tests/version-not-int.yaml
@@ -3,8 +3,7 @@ expected:
   traces:
     - traceql: '{ name =~ "SELECT .*cart"}'
       spans:
-        - contains: 'outdated oats test'
+        - contains: "outdated oats test"
   metrics:
     - promql: foo
-      value: '>= 0'
-
+      value: ">= 0"

--- a/yaml/testdata/oats-merged.yaml
+++ b/yaml/testdata/oats-merged.yaml
@@ -18,15 +18,15 @@ input:
 expected:
   traces:
     - traceql: '{ name =~ "SELECT .*cart"}'
-      regexp: 'SELECT .*cart'
+      regexp: "SELECT .*cart"
       attributes:
         db.system: h2
     - traceql: '{ name =~ "SELECT .*product"}'
-      regexp: 'SELECT .*cart'
+      regexp: "SELECT .*cart"
       attributes:
         db.system: h2
   metrics:
     - promql: foo
-      value: '>= 0'
+      value: ">= 0"
     - promql: bar
-      value: '>= 0'
+      value: ">= 0"

--- a/yaml/testdata/valid-tests/expect-absent.oats.yaml
+++ b/yaml/testdata/valid-tests/expect-absent.oats.yaml
@@ -4,21 +4,21 @@ input:
 expected:
   traces:
     - traceql: '{ name =~ "SELECT .*" }'
-      regexp: 'SELECT .*product'
+      regexp: "SELECT .*product"
       attributes:
         db.system: h2
     - traceql: '{ name =~ "SELECT .*" }'
-      regexp: 'nonexistent-span'
+      regexp: "nonexistent-span"
       count:
         min: 0
         max: 0
     - traceql: '{ span.kind = "client" }'
-      regexp: 'HTTP GET'
+      regexp: "HTTP GET"
     - traceql: '{ span.kind = "client" }'
-      regexp: 'filtered-span'
+      regexp: "filtered-span"
       count:
         min: 0
         max: 0
   metrics:
     - promql: test_metric
-      value: '>= 0'
+      value: ">= 0"

--- a/yaml/testdata/valid-tests/ignored/should-not-appear.oats.yaml
+++ b/yaml/testdata/valid-tests/ignored/should-not-appear.oats.yaml
@@ -4,5 +4,4 @@ include:
 expected:
   metrics:
     - promql: should_be_ignored
-      value: '>= 0'
-
+      value: ">= 0"

--- a/yaml/testdata/valid-tests/input.oats.yaml
+++ b/yaml/testdata/valid-tests/input.oats.yaml
@@ -19,4 +19,4 @@ input:
 expected:
   metrics:
     - promql: bar
-      value: '>= 0'
+      value: ">= 0"

--- a/yaml/testdata/valid-tests/matrix-test.oats.yaml
+++ b/yaml/testdata/valid-tests/matrix-test.oats.yaml
@@ -11,4 +11,3 @@ matrix:
       dir: k8s-manifests
       app-service: test-app
       app-docker-file: Dockerfile
-

--- a/yaml/testdata/valid-tests/more-oats.yml
+++ b/yaml/testdata/valid-tests/more-oats.yml
@@ -4,4 +4,4 @@ include:
 expected:
   logs:
     - logql: '{ service_name="foo" } |~ `Application started.`'
-      equals: 'Application started'
+      equals: "Application started"

--- a/yaml/testdata/valid-tests/oats-template.yaml
+++ b/yaml/testdata/valid-tests/oats-template.yaml
@@ -19,9 +19,9 @@ input:
 expected:
   traces:
     - traceql: '{ name =~ "SELECT .*product"}'
-      regexp: 'SELECT .*cart'
+      regexp: "SELECT .*cart"
       attributes:
         db.system: h2
   metrics:
     - promql: bar
-      value: '>= 0'
+      value: ">= 0"

--- a/yaml/testdata/valid-tests/oats.yaml
+++ b/yaml/testdata/valid-tests/oats.yaml
@@ -4,10 +4,9 @@ include:
 expected:
   traces:
     - traceql: '{ name =~ "SELECT .*cart"}'
-      regexp: 'SELECT .*cart'
+      regexp: "SELECT .*cart"
       attributes:
         db.system: h2
   metrics:
     - promql: foo
-      value: '>= 0'
-
+      value: ">= 0"


### PR DESCRIPTION
## Summary

- Fix README markdownlint issues.
- Add narrow Prettier ignores for templated and intentionally malformed YAML.
- Apply Prettier formatting to repo-owned YAML/JSONC fixtures.

Refs grafana/flint#213.

## Validation

- markdownlint-cli2 `**/*.md`
- prettier --check .
- push hook: mise run lint:fix (fast-only)