### PR TITLE
fix: wait for lgtm deployment availability

### DIFF
--- a/testhelpers/kubernetes/kubernetes.go
+++ b/testhelpers/kubernetes/kubernetes.go
@@ -101,7 +101,16 @@ func start(model *Kubernetes, ports remote.PortsConfig, testName string, run fun
 	if err != nil {
 		return err
 	}
-	err = run(exec.Command("kubectl", "wait", "--timeout=5m", "--for=condition=ready", "pod", "-l", "app=lgtm"), false)
+	err = run(
+		exec.Command(
+			"kubectl",
+			"wait",
+			"--timeout=5m",
+			"--for=condition=available",
+			"deployment/lgtm",
+		),
+		false,
+	)
 	if err != nil {
 		return err
 	}

--- a/testhelpers/kubernetes/kubernetes_test.go
+++ b/testhelpers/kubernetes/kubernetes_test.go
@@ -1,0 +1,45 @@
+package kubernetes
+
+import (
+	"os/exec"
+	"testing"
+
+	"github.com/grafana/oats/testhelpers/remote"
+	"github.com/stretchr/testify/require"
+)
+
+func TestStartWaitsForLgtmDeploymentAvailability(t *testing.T) {
+	t.Parallel()
+
+	model := &Kubernetes{
+		Dir:              "k8s",
+		AppService:       "dice",
+		AppDockerFile:    "Dockerfile",
+		AppDockerContext: ".",
+		AppDockerTag:     "dice:1.1-SNAPSHOT",
+		AppDockerPort:    8080,
+	}
+	ports := remote.PortsConfig{
+		LokiHttpPort:       3100,
+		PrometheusHTTPPort: 9090,
+		TempoHTTPPort:      3200,
+		PyroscopeHttpPort:  4040,
+	}
+
+	var commands [][]string
+	run := func(cmd *exec.Cmd, background bool) error {
+		commands = append(commands, append([]string(nil), cmd.Args...))
+		return nil
+	}
+
+	err := start(model, ports, "run-oats", run)
+	require.NoError(t, err)
+
+	require.Contains(t, commands, []string{
+		"kubectl",
+		"wait",
+		"--timeout=5m",
+		"--for=condition=available",
+		"deployment/lgtm",
+	})
+}


### PR DESCRIPTION
## What changed
- wait for `deployment/lgtm` to become `Available` instead of waiting on `pod -l app=lgtm`
- add a unit test covering the Kubernetes startup wait command sequence

## Why
The previous `kubectl wait --for=condition=ready pod -l app=lgtm` can fail immediately if no matching pod exists yet right after `kubectl apply`. That creates a race in k3d-backed acceptance tests.

## Impact
This makes OATS Kubernetes startup more robust for consumers like `open-telemetry/opentelemetry-java-examples` that hit the race after the `k3d` upgrade.

## Root cause
The helper waited on a pod selector before the deployment had necessarily created a pod. `kubectl wait` does not wait for matching resources to appear.

## Validation
- `go test ./testhelpers/kubernetes ./model ./yaml`
