### PR TITLE
feat(core): wait/assert/seed/report/cache/engine/signalcmd primitives

### DIFF
--- a/assert/assert.go
+++ b/assert/assert.go
@@ -1,0 +1,256 @@
+// Package assert holds the vocabulary OATS uses to check gcx output.
+//
+// Each function takes the captured stdout (or a parsed structure derived from
+// it) and an expectation, and returns a slice of failures — empty if the
+// expectation held. Functions never panic; they never short-circuit on the
+// first failure within a group. A case yaml that declares five Contains
+// substrings reports all five misses in one run, not just the first.
+//
+// The shape mirrors the YAML keys documented in the OATS v2 impl plan:
+// contains, not_contains, regex, value, count, absent.
+package assert
+
+import (
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+
+	"github.com/grafana/oats/casefile"
+)
+
+// Failure carries enough context to render a compact "FAIL <case>  <source>"
+// block. The Detail is the message body; the package never formats source
+// pointers itself — that's the renderer's job.
+type Failure struct {
+	Rule   string // "contains", "regex", "value", ...
+	Detail string
+}
+
+func (f Failure) Error() string { return f.Rule + ": " + f.Detail }
+
+// Row is the normalized structural unit used by collector-style `match`
+// assertions. Depending on the signal type, Name is the primary field
+// (`name` for traces, log body for logs, metric name for metrics) and
+// Attributes carries labels/attributes associated with that row.
+type Row struct {
+	Name       string
+	Attributes map[string]string
+}
+
+// Contains checks that each substring appears at least once in stdout.
+func Contains(stdout string, substrings []string) []Failure {
+	var fails []Failure
+	for _, s := range substrings {
+		if !strings.Contains(stdout, s) {
+			fails = append(fails, Failure{
+				Rule:   "contains",
+				Detail: fmt.Sprintf("substring %q not found in stdout", s),
+			})
+		}
+	}
+	return fails
+}
+
+// NotContains checks that none of the substrings appear in stdout.
+func NotContains(stdout string, substrings []string) []Failure {
+	var fails []Failure
+	for _, s := range substrings {
+		if strings.Contains(stdout, s) {
+			fails = append(fails, Failure{
+				Rule:   "not_contains",
+				Detail: fmt.Sprintf("substring %q unexpectedly present in stdout", s),
+			})
+		}
+	}
+	return fails
+}
+
+// Regex checks that each pattern matches stdout at least once. An invalid
+// pattern is itself reported as a failure — case yamls don't get to fail
+// silently on a bad regex.
+func Regex(stdout string, patterns []string) []Failure {
+	var fails []Failure
+	for _, p := range patterns {
+		re, err := regexp.Compile(p)
+		if err != nil {
+			fails = append(fails, Failure{
+				Rule:   "regex",
+				Detail: fmt.Sprintf("invalid pattern %q: %v", p, err),
+			})
+			continue
+		}
+		if !re.MatchString(stdout) {
+			fails = append(fails, Failure{
+				Rule:   "regex",
+				Detail: fmt.Sprintf("pattern %q did not match stdout", p),
+			})
+		}
+	}
+	return fails
+}
+
+// Value parses a numeric comparison expression ("> 0", ">= 1.5", "== 42",
+// "< 100", "<= 0", "!= 0") and checks it against the supplied actual value.
+// Used by metrics assertions; the actual value comes from parsing gcx
+// metrics query's JSON output upstream of this function.
+func Value(actual float64, expr string) []Failure {
+	op, rhs, err := parseValueExpr(expr)
+	if err != nil {
+		return []Failure{{Rule: "value", Detail: err.Error()}}
+	}
+	if !applyComparison(actual, op, rhs) {
+		return []Failure{{
+			Rule:   "value",
+			Detail: fmt.Sprintf("expected value %s, got %v", expr, actual),
+		}}
+	}
+	return nil
+}
+
+// Count is Value's sibling for integer cardinality. Same operators, integer
+// rhs only — "== 0", ">= 1", "< 10".
+func Count(actual int, expr string) []Failure {
+	// Delegate to Value via float64 — the parser is the same and integer
+	// comparisons through float64 are exact for any count we'd plausibly
+	// assert on.
+	return retag(Value(float64(actual), expr), "count")
+}
+
+// Absent is a convenience over Count: it asserts the count is exactly zero.
+// It is the spelling case-yaml authors use when "no traces matched" is the
+// expectation.
+func Absent(actual int) []Failure {
+	if actual != 0 {
+		return []Failure{{
+			Rule:   "absent",
+			Detail: fmt.Sprintf("expected zero results, got %d", actual),
+		}}
+	}
+	return nil
+}
+
+// MatchRows checks that each collector-style match entry is satisfied by at
+// least one row. Each entry is independent: one entry may match one row and
+// the next entry a different row.
+func MatchRows(rows []Row, entries []casefile.MatchEntry) []Failure {
+	var fails []Failure
+	for _, entry := range entries {
+		if !anyRowMatches(rows, entry) {
+			fails = append(fails, Failure{
+				Rule:   "match",
+				Detail: fmt.Sprintf("no row matched %s", describeMatch(entry)),
+			})
+		}
+	}
+	return fails
+}
+
+func anyRowMatches(rows []Row, entry casefile.MatchEntry) bool {
+	for _, row := range rows {
+		if rowMatches(row, entry) {
+			return true
+		}
+	}
+	return false
+}
+
+func rowMatches(row Row, entry casefile.MatchEntry) bool {
+	matchType := entry.EffectiveMatchType()
+	if entry.Name != nil {
+		if !matchesValue(row.Name, *entry.Name, matchType) {
+			return false
+		}
+	}
+	for _, expected := range entry.Attributes {
+		actual, ok := row.Attributes[expected.Key]
+		if expected.Value == nil {
+			if !ok {
+				return false
+			}
+			continue
+		}
+		if !ok {
+			return false
+		}
+		if !matchesValue(actual, *expected.Value, matchType) {
+			return false
+		}
+	}
+	return true
+}
+
+func matchesValue(actual, expected string, matchType casefile.MatchType) bool {
+	switch matchType {
+	case casefile.MatchTypeRegexp:
+		re, err := regexp.Compile(expected)
+		if err != nil {
+			return false
+		}
+		return re.MatchString(actual)
+	default:
+		return actual == expected
+	}
+}
+
+func describeMatch(entry casefile.MatchEntry) string {
+	var parts []string
+	if entry.MatchType != "" {
+		parts = append(parts, fmt.Sprintf("match_type=%s", entry.MatchType))
+	}
+	if entry.Name != nil {
+		parts = append(parts, fmt.Sprintf("name=%q", *entry.Name))
+	}
+	for _, expected := range entry.Attributes {
+		switch expected.Value {
+		case nil:
+			parts = append(parts, fmt.Sprintf("attribute %s present", expected.Key))
+		default:
+			parts = append(parts, fmt.Sprintf("attribute %s=%q", expected.Key, *expected.Value))
+		}
+	}
+	if len(parts) == 0 {
+		return "empty match entry"
+	}
+	return strings.Join(parts, ", ")
+}
+
+func retag(fails []Failure, rule string) []Failure {
+	for i := range fails {
+		fails[i].Rule = rule
+	}
+	return fails
+}
+
+func parseValueExpr(expr string) (op string, rhs float64, err error) {
+	expr = strings.TrimSpace(expr)
+	for _, candidate := range []string{">=", "<=", "==", "!=", ">", "<"} {
+		if strings.HasPrefix(expr, candidate) {
+			numStr := strings.TrimSpace(strings.TrimPrefix(expr, candidate))
+			n, parseErr := strconv.ParseFloat(numStr, 64)
+			if parseErr != nil {
+				return "", 0, fmt.Errorf("invalid numeric rhs in %q: %v", expr, parseErr)
+			}
+			return candidate, n, nil
+		}
+	}
+	return "", 0, fmt.Errorf("expected comparison operator (>, >=, <, <=, ==, !=) at start of %q", expr)
+}
+
+func applyComparison(lhs float64, op string, rhs float64) bool {
+	switch op {
+	case ">":
+		return lhs > rhs
+	case ">=":
+		return lhs >= rhs
+	case "<":
+		return lhs < rhs
+	case "<=":
+		return lhs <= rhs
+	case "==":
+		return lhs == rhs
+	case "!=":
+		return lhs != rhs
+	}
+	return false
+}

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -6,7 +6,7 @@
 // first failure within a group. A case yaml that declares five Contains
 // substrings reports all five misses in one run, not just the first.
 //
-// The shape mirrors the YAML keys documented in the OATS v2 impl plan:
+// The shape mirrors the case yaml keys documented in docs/case-reference.md:
 // contains, not_contains, regex, value, count, absent.
 package assert
 

--- a/assert/assert.go
+++ b/assert/assert.go
@@ -95,11 +95,11 @@ func Regex(stdout string, patterns []string) []Failure {
 // Used by metrics assertions; the actual value comes from parsing gcx
 // metrics query's JSON output upstream of this function.
 func Value(actual float64, expr string) []Failure {
-	op, rhs, err := parseValueExpr(expr)
+	op, threshold, err := parseValueExpr(expr)
 	if err != nil {
 		return []Failure{{Rule: "value", Detail: err.Error()}}
 	}
-	if !applyComparison(actual, op, rhs) {
+	if !applyComparison(actual, op, threshold) {
 		return []Failure{{
 			Rule:   "value",
 			Detail: fmt.Sprintf("expected value %s, got %v", expr, actual),
@@ -109,7 +109,7 @@ func Value(actual float64, expr string) []Failure {
 }
 
 // Count is Value's sibling for integer cardinality. Same operators, integer
-// rhs only — "== 0", ">= 1", "< 10".
+// threshold only — "== 0", ">= 1", "< 10".
 func Count(actual int, expr string) []Failure {
 	// Delegate to Value via float64 — the parser is the same and integer
 	// comparisons through float64 are exact for any count we'd plausibly
@@ -177,6 +177,9 @@ func rowMatches(row Row, entry casefile.MatchEntry) bool {
 			return false
 		}
 	}
+	// All specified constraints held. This is never vacuously true: casefile's
+	// validateMatchEntries rejects an entry with no name and no attributes, so
+	// a row reaching here has matched at least one real constraint.
 	return true
 }
 
@@ -215,6 +218,9 @@ func describeMatch(entry casefile.MatchEntry) string {
 	return strings.Join(parts, ", ")
 }
 
+// retag relabels a failure set's Rule field. Count and Absent delegate their
+// numeric comparison to Value, then retag the resulting "value" failures as
+// "count"/"absent" so the reported rule matches the assertion the author wrote.
 func retag(fails []Failure, rule string) []Failure {
 	for i := range fails {
 		fails[i].Rule = rule
@@ -222,35 +228,36 @@ func retag(fails []Failure, rule string) []Failure {
 	return fails
 }
 
-func parseValueExpr(expr string) (op string, rhs float64, err error) {
+func parseValueExpr(expr string) (op string, threshold float64, err error) {
 	expr = strings.TrimSpace(expr)
+	// Longest operators first so ">=" is matched before ">".
 	for _, candidate := range []string{">=", "<=", "==", "!=", ">", "<"} {
 		if strings.HasPrefix(expr, candidate) {
 			numStr := strings.TrimSpace(strings.TrimPrefix(expr, candidate))
 			n, parseErr := strconv.ParseFloat(numStr, 64)
 			if parseErr != nil {
-				return "", 0, fmt.Errorf("invalid numeric rhs in %q: %v", expr, parseErr)
+				return "", 0, fmt.Errorf("invalid numeric threshold in %q: %v", expr, parseErr)
 			}
 			return candidate, n, nil
 		}
 	}
-	return "", 0, fmt.Errorf("expected comparison operator (>, >=, <, <=, ==, !=) at start of %q", expr)
+	return "", 0, fmt.Errorf("expected comparison operator (>=, <=, ==, !=, >, <) at start of %q", expr)
 }
 
-func applyComparison(lhs float64, op string, rhs float64) bool {
+func applyComparison(actual float64, op string, threshold float64) bool {
 	switch op {
-	case ">":
-		return lhs > rhs
 	case ">=":
-		return lhs >= rhs
-	case "<":
-		return lhs < rhs
+		return actual >= threshold
 	case "<=":
-		return lhs <= rhs
+		return actual <= threshold
 	case "==":
-		return lhs == rhs
+		return actual == threshold
 	case "!=":
-		return lhs != rhs
+		return actual != threshold
+	case ">":
+		return actual > threshold
+	case "<":
+		return actual < threshold
 	}
 	return false
 }

--- a/assert/assert_test.go
+++ b/assert/assert_test.go
@@ -1,0 +1,146 @@
+package assert
+
+import (
+	"testing"
+
+	"github.com/grafana/oats/casefile"
+)
+
+func TestContains(t *testing.T) {
+	cases := []struct {
+		name       string
+		stdout     string
+		substrings []string
+		wantFails  int
+	}{
+		{"all present", "hello world foo bar", []string{"hello", "foo"}, 0},
+		{"one missing", "hello world", []string{"hello", "missing"}, 1},
+		{"all missing", "x", []string{"a", "b", "c"}, 3},
+		{"empty list", "anything", nil, 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Contains(tc.stdout, tc.substrings)
+			if len(got) != tc.wantFails {
+				t.Errorf("got %d failures, want %d: %v", len(got), tc.wantFails, got)
+			}
+		})
+	}
+}
+
+func TestNotContains(t *testing.T) {
+	if got := NotContains("hello world", []string{"goodbye"}); len(got) != 0 {
+		t.Errorf("expected zero failures, got %v", got)
+	}
+	if got := NotContains("hello world", []string{"hello"}); len(got) != 1 {
+		t.Errorf("expected one failure, got %d", len(got))
+	}
+}
+
+func TestRegex(t *testing.T) {
+	if got := Regex("err: 500", []string{`err: \d{3}`}); len(got) != 0 {
+		t.Errorf("expected match, got %v", got)
+	}
+	if got := Regex("err: 500", []string{`^err: 4\d{2}$`}); len(got) != 1 {
+		t.Errorf("expected one failure (no match), got %d", len(got))
+	}
+	if got := Regex("anything", []string{`[invalid`}); len(got) != 1 {
+		t.Errorf("expected one failure (invalid pattern), got %d", len(got))
+	}
+}
+
+func TestValue(t *testing.T) {
+	cases := []struct {
+		name      string
+		actual    float64
+		expr      string
+		wantFails int
+	}{
+		{">= holds", 5, ">= 1", 0},
+		{">= fails", 0, ">= 1", 1},
+		{"> holds", 1.5, "> 1", 0},
+		{"> fails on equal", 1.0, "> 1", 1},
+		{"<= holds", 0, "<= 0", 0},
+		{"== holds", 42, "== 42", 0},
+		{"== fails", 41, "== 42", 1},
+		{"!= holds", 1, "!= 0", 0},
+		{"bad operator", 0, "?? 1", 1},
+		{"bad rhs", 0, ">= banana", 1},
+		{"extra whitespace", 5, "  >=  1  ", 0},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got := Value(tc.actual, tc.expr)
+			if len(got) != tc.wantFails {
+				t.Errorf("got %d failures, want %d: %v", len(got), tc.wantFails, got)
+			}
+		})
+	}
+}
+
+func TestCount(t *testing.T) {
+	got := Count(3, ">= 1")
+	if len(got) != 0 {
+		t.Errorf("expected pass, got %v", got)
+	}
+	got = Count(0, ">= 1")
+	if len(got) != 1 || got[0].Rule != "count" {
+		t.Errorf("expected one count-tagged failure, got %v", got)
+	}
+}
+
+func TestAbsent(t *testing.T) {
+	if got := Absent(0); len(got) != 0 {
+		t.Errorf("expected pass, got %v", got)
+	}
+	if got := Absent(2); len(got) != 1 || got[0].Rule != "absent" {
+		t.Errorf("expected one absent-tagged failure, got %v", got)
+	}
+}
+
+func TestMatchRows(t *testing.T) {
+	rows := []Row{
+		{
+			Name: "seed-operation",
+			Attributes: map[string]string{
+				"service.name": "gcx-e2e-seed",
+				"trace_id":     "abc123",
+			},
+		},
+	}
+
+	got := MatchRows(rows, []casefile.MatchEntry{
+		{
+			Name: strPtr("seed-operation"),
+			Attributes: casefile.AttributeMatchers{
+				{Key: "service.name", Value: strPtr("gcx-e2e-seed")},
+				{Key: "trace_id"},
+			},
+		},
+	})
+	if len(got) != 0 {
+		t.Fatalf("expected match to pass, got %v", got)
+	}
+
+	got = MatchRows(rows, []casefile.MatchEntry{
+		{
+			MatchType:  casefile.MatchTypeRegexp,
+			Name:       strPtr("^seed-.*$"),
+			Attributes: casefile.AttributeMatchers{{Key: "trace_id", Value: strPtr("^abc")}},
+		},
+	})
+	if len(got) != 0 {
+		t.Fatalf("expected regexp match to pass, got %v", got)
+	}
+
+	got = MatchRows(rows, []casefile.MatchEntry{
+		{
+			Attributes: casefile.AttributeMatchers{{Key: "missing"}},
+		},
+	})
+	if len(got) != 1 || got[0].Rule != "match" {
+		t.Fatalf("expected one match failure, got %v", got)
+	}
+}
+
+func strPtr(s string) *string { return &s }

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,0 +1,154 @@
+// Package cache holds OATS v2's skip-when-unchanged store.
+//
+// Idea: if (this case yaml, this fixture config, this gcx version) all hash
+// to the same value as a previous green run within the TTL, skip the case.
+// On a hit, the runner emits a case.skip event and moves on. On a miss, the
+// case runs as usual; on pass, we record the hash. On fail, we evict the
+// entry.
+//
+// Storage is one file per hash under cacheDir, holding a single RFC3339
+// timestamp. Crude on purpose — there is no daemon to coordinate eviction,
+// no concurrent-write protocol beyond "last writer wins." A v2.1 enhancement
+// could move to a single index file if directory listings become slow.
+package cache
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+	"time"
+)
+
+// DefaultTTL is applied when CacheConfig.TTLDays is zero. One week strikes a
+// balance: long enough that local dev re-runs are essentially free, short
+// enough that a stale entry from before a gcx upgrade doesn't survive
+// indefinitely.
+const DefaultTTL = 7 * 24 * time.Hour
+
+// Store is the on-disk cache.
+type Store struct {
+	dir string
+	ttl time.Duration
+	now func() time.Time
+}
+
+// New constructs a Store rooted at dir. dir is created if absent. ttl=0
+// means "use DefaultTTL." now is a clock injection point for tests; nil
+// uses time.Now.
+func New(dir string, ttl time.Duration, now func() time.Time) (*Store, error) {
+	if dir == "" {
+		return nil, fmt.Errorf("cache: dir is required")
+	}
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		return nil, fmt.Errorf("cache: mkdir %s: %w", dir, err)
+	}
+	if ttl <= 0 {
+		ttl = DefaultTTL
+	}
+	if now == nil {
+		now = time.Now
+	}
+	return &Store{dir: dir, ttl: ttl, now: now}, nil
+}
+
+// Key represents the inputs that, taken together, decide whether a case is
+// safe to skip. All fields participate in the hash; an unset field hashes
+// the same as an empty string, so two callers must agree on whether to set
+// optional fields.
+type Key struct {
+	CaseYAML     []byte
+	FixtureBytes []byte
+	GCXVersion   string
+	OatsVersion  string
+	// Extra is an open-ended hook for callers that want to invalidate on
+	// something beyond the canonical fields (e.g. image digest once compose
+	// fixtures track that). Keys are sorted before hashing for stability.
+	Extra map[string]string
+}
+
+// Hash returns the canonical hex hash of Key. Stable across processes and OS.
+func (k Key) Hash() string {
+	h := sha256.New()
+	_, _ = h.Write([]byte("oats-cache-v1\n"))
+	_, _ = h.Write([]byte("case:\n"))
+	_, _ = h.Write(k.CaseYAML)
+	_, _ = h.Write([]byte("\nfixture:\n"))
+	_, _ = h.Write(k.FixtureBytes)
+	_, _ = h.Write([]byte("\ngcx:" + k.GCXVersion + "\noats:" + k.OatsVersion))
+	if len(k.Extra) > 0 {
+		_, _ = h.Write([]byte("\nextra:\n"))
+		keys := make([]string, 0, len(k.Extra))
+		for k := range k.Extra {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+		for _, name := range keys {
+			_, _ = h.Write([]byte(name + "=" + k.Extra[name] + "\n"))
+		}
+	}
+	return hex.EncodeToString(h.Sum(nil))
+}
+
+// Lookup reports whether Key is recorded as green within the TTL.
+// Returns (hit, recordedAt). On miss, recordedAt is the zero value.
+func (s *Store) Lookup(k Key) (bool, time.Time) {
+	hash := k.Hash()
+	path := filepath.Join(s.dir, hash)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, time.Time{}
+	}
+	ts, err := time.Parse(time.RFC3339Nano, strings.TrimSpace(string(data)))
+	if err != nil {
+		// Corrupt entry — best to evict so we don't keep returning false
+		// positives. Errors are silent: the cache is advisory.
+		_ = os.Remove(path)
+		return false, time.Time{}
+	}
+	if s.now().Sub(ts) > s.ttl {
+		// Expired. Eager eviction keeps directory size bounded.
+		_ = os.Remove(path)
+		return false, time.Time{}
+	}
+	return true, ts
+}
+
+// Record marks Key as green at "now."
+func (s *Store) Record(k Key) error {
+	hash := k.Hash()
+	path := filepath.Join(s.dir, hash)
+	return os.WriteFile(path, []byte(s.now().Format(time.RFC3339Nano)), 0o644)
+}
+
+// Evict removes any entry for Key, regardless of age.
+func (s *Store) Evict(k Key) error {
+	hash := k.Hash()
+	err := os.Remove(filepath.Join(s.dir, hash))
+	if os.IsNotExist(err) {
+		return nil
+	}
+	return err
+}
+
+// Clear removes every entry in the cache directory. Convenience for the
+// "oats cache clear" subcommand that will land alongside the migration
+// tool.
+func (s *Store) Clear() error {
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		return err
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if err := os.Remove(filepath.Join(s.dir, e.Name())); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -1,4 +1,4 @@
-// Package cache holds OATS v2's skip-when-unchanged store.
+// Package cache holds OATS's skip-when-unchanged store.
 //
 // Idea: if (this case yaml, this fixture config, this gcx version) all hash
 // to the same value as a previous green run within the TTL, skip the case.

--- a/cache/cache.go
+++ b/cache/cache.go
@@ -8,8 +8,13 @@
 //
 // Storage is one file per hash under cacheDir, holding a single RFC3339
 // timestamp. Crude on purpose — there is no daemon to coordinate eviction,
-// no concurrent-write protocol beyond "last writer wins." A v2.1 enhancement
+// no concurrent-write protocol beyond "last writer wins." A future enhancement
 // could move to a single index file if directory listings become slow.
+//
+// There is no hard cap on entry count: files accumulate one per
+// (case, fixture, gcx version) key, and expired entries are evicted lazily on
+// access, so TTL bounds growth in practice. A size/count cap is a possible
+// future enhancement if a long-lived cache dir ever grows unwieldy.
 package cache
 
 import (

--- a/cache/cache_test.go
+++ b/cache/cache_test.go
@@ -1,0 +1,152 @@
+package cache
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+)
+
+func TestHash_StableAcrossCalls(t *testing.T) {
+	k := Key{CaseYAML: []byte("name: x\n"), GCXVersion: "1.2.3"}
+	if a, b := k.Hash(), k.Hash(); a != b {
+		t.Errorf("hash unstable: %q vs %q", a, b)
+	}
+}
+
+func TestHash_DiffersOnAnyField(t *testing.T) {
+	base := Key{CaseYAML: []byte("a"), FixtureBytes: []byte("b"), GCXVersion: "v1", OatsVersion: "v2"}
+	bytesBase := base.Hash()
+
+	variations := []Key{
+		{CaseYAML: []byte("a-modified"), FixtureBytes: []byte("b"), GCXVersion: "v1", OatsVersion: "v2"},
+		{CaseYAML: []byte("a"), FixtureBytes: []byte("b-modified"), GCXVersion: "v1", OatsVersion: "v2"},
+		{CaseYAML: []byte("a"), FixtureBytes: []byte("b"), GCXVersion: "v1-modified", OatsVersion: "v2"},
+		{CaseYAML: []byte("a"), FixtureBytes: []byte("b"), GCXVersion: "v1", OatsVersion: "v2-modified"},
+		{CaseYAML: []byte("a"), FixtureBytes: []byte("b"), GCXVersion: "v1", OatsVersion: "v2", Extra: map[string]string{"k": "v"}},
+	}
+	for i, v := range variations {
+		if v.Hash() == bytesBase {
+			t.Errorf("variation %d: hash collides with base", i)
+		}
+	}
+}
+
+func TestHash_ExtraOrderIndependent(t *testing.T) {
+	a := Key{Extra: map[string]string{"x": "1", "y": "2"}}.Hash()
+	b := Key{Extra: map[string]string{"y": "2", "x": "1"}}.Hash()
+	if a != b {
+		t.Errorf("Extra map order changed hash: %s vs %s", a, b)
+	}
+}
+
+func TestLookupMiss(t *testing.T) {
+	s, _ := New(t.TempDir(), 0, nil)
+	hit, _ := s.Lookup(Key{CaseYAML: []byte("x")})
+	if hit {
+		t.Error("expected miss on empty cache")
+	}
+}
+
+func TestRecordThenLookup(t *testing.T) {
+	s, _ := New(t.TempDir(), 0, nil)
+	k := Key{CaseYAML: []byte("x")}
+	if err := s.Record(k); err != nil {
+		t.Fatal(err)
+	}
+	hit, ts := s.Lookup(k)
+	if !hit {
+		t.Fatal("expected hit after Record")
+	}
+	if ts.IsZero() {
+		t.Error("expected non-zero timestamp")
+	}
+}
+
+func TestTTLExpiry(t *testing.T) {
+	clock := time.Now()
+	s, _ := New(t.TempDir(), time.Hour, func() time.Time { return clock })
+
+	k := Key{CaseYAML: []byte("x")}
+	if err := s.Record(k); err != nil {
+		t.Fatal(err)
+	}
+
+	// Within TTL.
+	if hit, _ := s.Lookup(k); !hit {
+		t.Error("fresh entry should hit")
+	}
+
+	// Push clock past TTL.
+	clock = clock.Add(2 * time.Hour)
+	if hit, _ := s.Lookup(k); hit {
+		t.Error("expired entry should miss")
+	}
+}
+
+func TestExpiredEntryIsEvicted(t *testing.T) {
+	clock := time.Now()
+	dir := t.TempDir()
+	s, _ := New(dir, time.Hour, func() time.Time { return clock })
+	k := Key{CaseYAML: []byte("x")}
+
+	if err := s.Record(k); err != nil {
+		t.Fatal(err)
+	}
+	clock = clock.Add(2 * time.Hour)
+	_, _ = s.Lookup(k)
+
+	// File should be gone.
+	if _, err := os.Stat(filepath.Join(dir, k.Hash())); !os.IsNotExist(err) {
+		t.Errorf("expected eviction; stat: %v", err)
+	}
+}
+
+func TestEvict(t *testing.T) {
+	s, _ := New(t.TempDir(), 0, nil)
+	k := Key{CaseYAML: []byte("x")}
+	_ = s.Record(k)
+	if err := s.Evict(k); err != nil {
+		t.Fatal(err)
+	}
+	if hit, _ := s.Lookup(k); hit {
+		t.Error("expected miss after Evict")
+	}
+	// Idempotent.
+	if err := s.Evict(k); err != nil {
+		t.Errorf("Evict on missing key should be no-op, got %v", err)
+	}
+}
+
+func TestClear(t *testing.T) {
+	s, _ := New(t.TempDir(), 0, nil)
+	_ = s.Record(Key{CaseYAML: []byte("a")})
+	_ = s.Record(Key{CaseYAML: []byte("b")})
+	_ = s.Record(Key{CaseYAML: []byte("c")})
+
+	if err := s.Clear(); err != nil {
+		t.Fatal(err)
+	}
+	for _, body := range []string{"a", "b", "c"} {
+		if hit, _ := s.Lookup(Key{CaseYAML: []byte(body)}); hit {
+			t.Errorf("expected all-miss after Clear, %q still hit", body)
+		}
+	}
+}
+
+func TestCorruptEntryIsEvicted(t *testing.T) {
+	dir := t.TempDir()
+	s, _ := New(dir, 0, nil)
+	k := Key{CaseYAML: []byte("x")}
+	// Write a bogus timestamp.
+	if err := os.WriteFile(filepath.Join(dir, k.Hash()), []byte("not a timestamp"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	hit, _ := s.Lookup(k)
+	if hit {
+		t.Error("corrupt entry should not hit")
+	}
+	if _, err := os.Stat(filepath.Join(dir, k.Hash())); !os.IsNotExist(err) {
+		t.Errorf("corrupt entry should be evicted; stat: %v", err)
+	}
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -46,7 +46,7 @@ type GCX struct {
 	Binary string
 
 	// Context is the value passed via --context, prepended to every invocation
-	// when non-empty. OATS sets this per suite so that a single binary install
+	// when non-empty. OATS sets this per fixture group so that a single binary install
 	// can drive multiple Grafana endpoints.
 	Context string
 

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -1,0 +1,129 @@
+// Package engine executes gcx CLI commands and returns the result.
+//
+// engine is the seam between OATS and gcx: OATS no longer talks HTTP to Tempo,
+// Loki, Prometheus, or Pyroscope. It builds a gcx command, runs it through an
+// Executor, and hands the captured output to the assert package.
+//
+// The Executor interface keeps tests fast — production wiring uses GCX, which
+// shells out via os/exec; tests use a stub that returns canned Results.
+package engine
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"time"
+)
+
+// Result captures everything a downstream assertion might need from a single
+// gcx invocation. ExitCode is captured separately from any Go-level error so
+// callers can distinguish "process did not start" from "process ran and
+// reported a non-zero status."
+type Result struct {
+	Command  []string
+	Stdout   string
+	Stderr   string
+	ExitCode int
+	Duration time.Duration
+}
+
+// Executor runs a gcx invocation and returns its Result.
+//
+// Implementations must never return a non-nil error for a non-zero exit code —
+// that is conveyed via Result.ExitCode. A non-nil error means the invocation
+// did not complete normally: the process could not be launched (missing
+// binary, permission denied) or the context was cancelled / timed out (before
+// or during the run).
+type Executor interface {
+	Execute(ctx context.Context, args ...string) (*Result, error)
+}
+
+// GCX is the production Executor. It shells out to a gcx binary on disk.
+type GCX struct {
+	// Binary is the path to the gcx executable. Required.
+	Binary string
+
+	// Context is the value passed via --context, prepended to every invocation
+	// when non-empty. OATS sets this per suite so that a single binary install
+	// can drive multiple Grafana endpoints.
+	Context string
+
+	// Config is an optional path passed via --config before every invocation.
+	// OATS uses this for local LGTM fixtures so gcx can query local datasources
+	// without consumer-managed wrapper scripts or ambient config state.
+	Config string
+
+	// Env supplements os.Environ() for the child process. Use to pass HOME /
+	// XDG_CONFIG_HOME for config isolation.
+	Env []string
+
+	// Timeout caps a single invocation. Zero means no per-invocation timeout —
+	// the caller's context deadline still applies.
+	Timeout time.Duration
+}
+
+// Execute runs gcx with args. When set, GCX.Config and GCX.Context are
+// prepended automatically (as "--config <cfg> --context <ctx>"), so callers
+// pass just the verb and its flags (e.g. "traces", "search", "--since=10m",
+// "{ ... }").
+func (g *GCX) Execute(ctx context.Context, args ...string) (*Result, error) {
+	if g.Binary == "" {
+		return nil, fmt.Errorf("engine: gcx binary path is empty")
+	}
+
+	full := args
+	if g.Context != "" {
+		full = append([]string{"--context", g.Context}, full...)
+	}
+	if g.Config != "" {
+		full = append([]string{"--config", g.Config}, full...)
+	}
+
+	if g.Timeout > 0 {
+		var cancel context.CancelFunc
+		ctx, cancel = context.WithTimeout(ctx, g.Timeout)
+		defer cancel()
+	}
+
+	cmd := exec.CommandContext(ctx, g.Binary, full...)
+	if len(g.Env) > 0 {
+		cmd.Env = append(cmd.Environ(), g.Env...)
+	}
+
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	start := time.Now()
+	err := cmd.Run()
+	duration := time.Since(start)
+
+	result := &Result{
+		Command:  append([]string{g.Binary}, full...),
+		Stdout:   stdout.String(),
+		Stderr:   stderr.String(),
+		Duration: duration,
+	}
+
+	// Timeout / cancellation takes precedence over exit code so callers can
+	// distinguish "gcx ran and failed" from "gcx was killed before it could
+	// answer."
+	if ctx.Err() != nil {
+		return result, fmt.Errorf("engine: gcx invocation aborted: %w", ctx.Err())
+	}
+
+	if err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			// Non-zero exit — surface via ExitCode, not via Go error.
+			result.ExitCode = exitErr.ExitCode()
+			return result, nil
+		}
+		// Process did not start, was killed by the OS, permission denied, etc.
+		return result, fmt.Errorf("engine: gcx invocation failed: %w", err)
+	}
+
+	return result, nil
+}

--- a/engine/engine.go
+++ b/engine/engine.go
@@ -87,6 +87,10 @@ func (g *GCX) Execute(ctx context.Context, args ...string) (*Result, error) {
 		defer cancel()
 	}
 
+	// CommandContext ties the process lifetime to ctx: when ctx is cancelled —
+	// by the per-invocation timeout above, or by an interrupt (the CLI runs
+	// under a context cancelled on SIGINT/SIGTERM) — the gcx process is killed
+	// rather than left running.
 	cmd := exec.CommandContext(ctx, g.Binary, full...)
 	if len(g.Env) > 0 {
 		cmd.Env = append(cmd.Environ(), g.Env...)

--- a/engine/engine_test.go
+++ b/engine/engine_test.go
@@ -1,0 +1,81 @@
+package engine
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestGCX_ExecuteCapturesStdout(t *testing.T) {
+	g := &GCX{Binary: "/bin/sh"}
+	r, err := g.Execute(context.Background(), "-c", "echo hello")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if r.ExitCode != 0 {
+		t.Errorf("ExitCode: got %d, want 0", r.ExitCode)
+	}
+	if got := strings.TrimSpace(r.Stdout); got != "hello" {
+		t.Errorf("Stdout: got %q, want %q", got, "hello")
+	}
+}
+
+func TestGCX_ExecuteCapturesStderr(t *testing.T) {
+	g := &GCX{Binary: "/bin/sh"}
+	r, err := g.Execute(context.Background(), "-c", "echo oops >&2")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got := strings.TrimSpace(r.Stderr); got != "oops" {
+		t.Errorf("Stderr: got %q, want %q", got, "oops")
+	}
+}
+
+func TestGCX_NonZeroExitIsNotAnError(t *testing.T) {
+	g := &GCX{Binary: "/bin/sh"}
+	r, err := g.Execute(context.Background(), "-c", "exit 7")
+	if err != nil {
+		t.Fatalf("non-zero exit should not return a Go error, got %v", err)
+	}
+	if r.ExitCode != 7 {
+		t.Errorf("ExitCode: got %d, want 7", r.ExitCode)
+	}
+}
+
+func TestGCX_MissingBinaryIsAnError(t *testing.T) {
+	g := &GCX{Binary: ""}
+	_, err := g.Execute(context.Background(), "anything")
+	if err == nil {
+		t.Fatal("expected an error for empty binary path")
+	}
+}
+
+func TestGCX_PrependsContextFlag(t *testing.T) {
+	g := &GCX{Binary: "/bin/sh", Context: "my-ctx"}
+	r, err := g.Execute(context.Background(), "-c", `printf "%s\n" "$@"`, "_", "verb")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	// The command we asked sh to run echoes the positional args. With our
+	// Context set, gcx invocations gain a leading "--context my-ctx" pair.
+	// Since we're using /bin/sh as a stand-in for gcx, we observe the args
+	// by way of the recorded Command.
+	want := []string{"/bin/sh", "--context", "my-ctx", "-c", `printf "%s\n" "$@"`, "_", "verb"}
+	if len(r.Command) != len(want) {
+		t.Fatalf("Command len: got %d, want %d (%v)", len(r.Command), len(want), r.Command)
+	}
+	for i := range want {
+		if r.Command[i] != want[i] {
+			t.Errorf("Command[%d]: got %q, want %q", i, r.Command[i], want[i])
+		}
+	}
+}
+
+func TestGCX_TimeoutKillsLongProcess(t *testing.T) {
+	g := &GCX{Binary: "/bin/sh", Timeout: 50 * time.Millisecond}
+	_, err := g.Execute(context.Background(), "-c", "sleep 5")
+	if err == nil {
+		t.Fatal("expected an error when child overruns the timeout")
+	}
+}

--- a/report/event.go
+++ b/report/event.go
@@ -1,4 +1,4 @@
-// Package report carries OATS v2's observation channel.
+// Package report carries OATS's observation channel.
 //
 // Every interesting moment in a run — a case started, an assertion failed, a
 // fixture became ready — is published as an Event. A Reporter renders the

--- a/report/event.go
+++ b/report/event.go
@@ -1,0 +1,98 @@
+// Package report carries OATS v2's observation channel.
+//
+// Every interesting moment in a run — a case started, an assertion failed, a
+// fixture became ready — is published as an Event. A Reporter renders the
+// stream for a particular audience: the compact text format for humans and
+// agents alike (the default), or NDJSON for tooling that wants to consume
+// events structurally.
+//
+// The same Event vocabulary feeds both renderers. The CI-annotation emitter
+// is a thin layer over the text renderer that fires when GITHUB_ACTIONS=true.
+package report
+
+import "time"
+
+// EventType is the canonical lifecycle vocabulary. New types should be added
+// here and then handled by all renderers — emitting an unknown type must
+// remain safe (renderers either drop it or render a neutral line).
+type EventType string
+
+const (
+	EventRunStart        EventType = "run.start"
+	EventRunEnd          EventType = "run.end"
+	EventSuiteStart      EventType = "suite.start"
+	EventSuiteEnd        EventType = "suite.end"
+	EventFixtureStart    EventType = "fixture.start"
+	EventFixtureReady    EventType = "fixture.ready"
+	EventFixtureTeardown EventType = "fixture.teardown"
+	EventCaseStart       EventType = "case.start"
+	EventCasePass        EventType = "case.pass"
+	EventCaseFail        EventType = "case.fail"
+	EventCaseSkip        EventType = "case.skip"
+	EventAssertFail      EventType = "assert.fail"
+	EventGCXExec         EventType = "gcx.exec"
+)
+
+// SchemaVersion travels with each run.start event. Consumers pin to a
+// version; we bump on any breaking change (key removed, key semantics
+// changed). Additive changes are not breaking.
+const SchemaVersion = 1
+
+// Event is the single payload type that crosses the Reporter boundary.
+// Fields are sparse on purpose — each event type populates only what it
+// needs, and Reporters MUST tolerate missing values for fields outside an
+// event's natural set.
+//
+// JSON tags drive NDJSON output. The TextReporter uses the same fields but
+// formats them prose-side.
+type Event struct {
+	Type EventType `json:"event"`
+	Ts   time.Time `json:"ts,omitempty"`
+
+	// Set on run.start only.
+	OatsVersion   string `json:"oats_version,omitempty"`
+	SchemaVersion int    `json:"schema_version,omitempty"`
+
+	// Identifying context.
+	Suite       string `json:"suite,omitempty"`
+	FixtureType string `json:"fixture_type,omitempty"`
+	Case        string `json:"case,omitempty"`
+	Source      string `json:"source,omitempty"`
+
+	// Per-assertion / per-failure detail.
+	Msg           string `json:"msg,omitempty"`
+	Cmd           string `json:"cmd,omitempty"`
+	StdoutExcerpt string `json:"stdout_excerpt,omitempty"`
+
+	// Timing and aggregate counts.
+	DurationMs int64 `json:"duration_ms,omitempty"`
+	CaseCount  int   `json:"case_count,omitempty"`
+	Pass       int   `json:"pass,omitempty"`
+	Fail       int   `json:"fail,omitempty"`
+	Skip       int   `json:"skip,omitempty"`
+}
+
+// Reporter consumes Events as they happen and flushes its final output when
+// Close is called. Concrete implementations must be safe for sequential use
+// (no concurrent Emit calls — the runner serialises them).
+type Reporter interface {
+	Emit(e Event)
+	Close() error
+}
+
+// Verbosity controls how much detail the renderers emit. TextReporter uses
+// it for pass/cmd/lifecycle chatter; NDJSON applies the same gates to
+// case.pass, gcx.exec, and fixture lifecycle events.
+type Verbosity int
+
+const (
+	// VerboseDefault prints failures plus the final summary. Pass events,
+	// fixture lifecycle, and gcx exec details are silent.
+	VerboseDefault Verbosity = iota
+	// VerbosePasses adds one line per passing case.
+	VerbosePasses
+	// VerboseCmd adds the gcx invocation behind each assertion (pass or fail).
+	VerboseCmd
+	// VerboseAll adds fixture lifecycle and full gcx stdout / per-phase timing.
+	VerboseAll
+)

--- a/report/ndjson.go
+++ b/report/ndjson.go
@@ -1,0 +1,48 @@
+package report
+
+import (
+	"encoding/json"
+	"io"
+)
+
+// NDJSONReporter emits one JSON object per Event on its own line. Suitable
+// for tooling that wants to consume events structurally. Pass and gcx.exec
+// events are filtered by Verbosity in the same spirit as TextReporter so the
+// token cost of "everything went fine" remains zero.
+type NDJSONReporter struct {
+	w   io.Writer
+	enc *json.Encoder
+	v   Verbosity
+}
+
+func NewNDJSONReporter(w io.Writer, v Verbosity) *NDJSONReporter {
+	enc := json.NewEncoder(w)
+	// Compact form: no HTML escaping, no extra whitespace beyond the
+	// trailing newline json.Encoder emits per Encode.
+	enc.SetEscapeHTML(false)
+	return &NDJSONReporter{w: w, enc: enc, v: v}
+}
+
+func (r *NDJSONReporter) Emit(e Event) {
+	if !r.shouldEmit(e) {
+		return
+	}
+	// Failure to write the stream is silent on purpose: a downstream pipe
+	// that died should not crash the runner. The terminal exit status still
+	// reflects the test outcome.
+	_ = r.enc.Encode(e)
+}
+
+func (r *NDJSONReporter) Close() error { return nil }
+
+func (r *NDJSONReporter) shouldEmit(e Event) bool {
+	switch e.Type {
+	case EventCasePass:
+		return r.v >= VerbosePasses
+	case EventGCXExec:
+		return r.v >= VerboseCmd
+	case EventFixtureStart, EventFixtureReady, EventFixtureTeardown:
+		return r.v >= VerboseAll
+	}
+	return true
+}

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -1,0 +1,245 @@
+package report
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestTextReporter_SilentOnAllPass(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf, VerboseDefault)
+	r.Emit(Event{Type: EventRunStart, OatsVersion: "test"})
+	r.Emit(Event{Type: EventCasePass, Case: "a"})
+	r.Emit(Event{Type: EventCasePass, Case: "b"})
+	r.Emit(Event{Type: EventRunEnd, DurationMs: 100})
+
+	out := buf.String()
+	if strings.Contains(out, "FAIL") {
+		t.Errorf("no FAIL block expected on all-pass run:\n%s", out)
+	}
+	if !strings.Contains(out, "PASS 2/2") {
+		t.Errorf("summary line missing:\n%s", out)
+	}
+}
+
+func TestTextReporter_FailureBlockHasSourceAndCmd(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf, VerboseDefault)
+	r.Emit(Event{Type: EventRunStart})
+	r.Emit(Event{Type: EventCaseStart, Case: "rolldice", Source: "examples/nodejs/oats.yaml:1"})
+	r.Emit(Event{
+		Type:   EventAssertFail,
+		Case:   "rolldice",
+		Source: "examples/nodejs/oats.yaml:8",
+		Msg:    "TraceQL returned no results",
+		Cmd:    "gcx traces search '{ span.http.route = \"/rolldice\" }'",
+	})
+	r.Emit(Event{Type: EventCaseFail, Case: "rolldice"})
+	r.Emit(Event{Type: EventRunEnd})
+
+	out := buf.String()
+	if !strings.Contains(out, "FAIL rolldice  examples/nodejs/oats.yaml:8") {
+		t.Errorf("FAIL header missing or wrong:\n%s", out)
+	}
+	if !strings.Contains(out, "TraceQL returned no results") {
+		t.Errorf("failure message missing:\n%s", out)
+	}
+	if !strings.Contains(out, "gcx traces search") {
+		t.Errorf("command missing:\n%s", out)
+	}
+	if !strings.Contains(out, "FAIL 0/1 (1 failed") {
+		t.Errorf("summary line missing or wrong:\n%s", out)
+	}
+}
+
+func TestTextReporter_GHAAnnotationsWhenEnabled(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf, VerboseDefault)
+	r.Emit(Event{Type: EventRunStart})
+	r.Emit(Event{
+		Type:   EventAssertFail,
+		Case:   "x",
+		Source: "examples/nodejs/oats.yaml:8",
+		Msg:    "oops",
+	})
+	// Same source twice — only one annotation should appear.
+	r.Emit(Event{
+		Type:   EventAssertFail,
+		Case:   "x",
+		Source: "examples/nodejs/oats.yaml:8",
+		Msg:    "again",
+	})
+	r.Emit(Event{Type: EventCaseFail, Case: "x"})
+	r.Emit(Event{Type: EventRunEnd})
+
+	out := buf.String()
+	expectedAnnotation := "::error file=examples/nodejs/oats.yaml,line=8::oops"
+	if !strings.Contains(out, expectedAnnotation) {
+		t.Errorf("expected annotation missing:\n%s", out)
+	}
+	if strings.Count(out, "::error file=") != 1 {
+		t.Errorf("duplicate annotations not deduplicated:\n%s", out)
+	}
+}
+
+func TestTextReporter_GHAAnnotationsWithoutSource(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf, VerboseDefault)
+	r.Emit(Event{Type: EventRunStart})
+	r.Emit(Event{
+		Type: EventAssertFail,
+		Case: "x",
+		Msg:  "oops",
+	})
+	r.Emit(Event{Type: EventCaseFail, Case: "x"})
+	r.Emit(Event{Type: EventRunEnd})
+
+	out := buf.String()
+	if !strings.Contains(out, "::error::oops") {
+		t.Fatalf("expected source-free gha annotation:\n%s", out)
+	}
+	if strings.Contains(out, "::error file=") {
+		t.Fatalf("did not expect empty file annotation:\n%s", out)
+	}
+}
+
+func TestTextReporter_GHAAnnotationEscaping(t *testing.T) {
+	t.Setenv("GITHUB_ACTIONS", "true")
+
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf, VerboseDefault)
+	r.Emit(Event{Type: EventRunStart})
+	r.Emit(Event{
+		Type:   EventAssertFail,
+		Case:   "x",
+		Source: "path/with,comma:x/a.yaml:8",
+		Msg:    "line one\nline two 50% off",
+	})
+	r.Emit(Event{Type: EventCaseFail, Case: "x"})
+	r.Emit(Event{Type: EventRunEnd})
+
+	out := buf.String()
+	// Message: %, CR and LF encoded so the annotation is not truncated.
+	if !strings.Contains(out, "line one%0Aline two 50%25 off") {
+		t.Errorf("message not escaped:\n%s", out)
+	}
+	// Property: message rules plus : and , so delimiters are not misread.
+	if !strings.Contains(out, "file=path/with%2Ccomma%3Ax/a.yaml,line=8::") {
+		t.Errorf("file property not escaped:\n%s", out)
+	}
+}
+
+func TestTextReporter_VerbosePassPrintsPasses(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf, VerbosePasses)
+	r.Emit(Event{Type: EventRunStart})
+	r.Emit(Event{Type: EventCasePass, Case: "a"})
+	r.Emit(Event{Type: EventRunEnd})
+
+	if !strings.Contains(buf.String(), "PASS a\n") {
+		t.Errorf("expected per-case PASS line:\n%s", buf.String())
+	}
+}
+
+func TestTextReporter_VerboseAllPrintsFixtureLifecycle(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewTextReporter(&buf, VerboseAll)
+	r.Emit(Event{Type: EventFixtureStart, FixtureType: "compose", DurationMs: 1})
+	r.Emit(Event{Type: EventFixtureReady, FixtureType: "compose", DurationMs: 12})
+	r.Emit(Event{Type: EventFixtureTeardown, FixtureType: "compose", DurationMs: 3})
+
+	out := buf.String()
+	for _, want := range []string{
+		"[fixture compose] fixture.start",
+		"[fixture compose] fixture.ready",
+		"[fixture compose] fixture.teardown",
+	} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected fixture lifecycle line %q in:\n%s", want, out)
+		}
+	}
+}
+
+func TestNDJSONReporter_EmitsOneJSONObjectPerLine(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewNDJSONReporter(&buf, VerboseDefault)
+	r.Emit(Event{Type: EventRunStart, OatsVersion: "x", SchemaVersion: 1, Ts: time.Now()})
+	r.Emit(Event{Type: EventCaseFail, Case: "rolldice", DurationMs: 1234})
+	r.Emit(Event{Type: EventRunEnd, Pass: 0, Fail: 1})
+
+	lines := strings.Split(strings.TrimSpace(buf.String()), "\n")
+	if len(lines) != 3 {
+		t.Fatalf("expected 3 lines, got %d:\n%s", len(lines), buf.String())
+	}
+	for _, line := range lines {
+		var e map[string]any
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("invalid JSON line %q: %v", line, err)
+		}
+	}
+}
+
+func TestNDJSONReporter_FiltersPassByDefault(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewNDJSONReporter(&buf, VerboseDefault)
+	r.Emit(Event{Type: EventCasePass, Case: "a"})
+	r.Emit(Event{Type: EventCaseFail, Case: "b"})
+
+	if strings.Contains(buf.String(), `"case.pass"`) {
+		t.Errorf("pass event leaked through default verbosity:\n%s", buf.String())
+	}
+	if !strings.Contains(buf.String(), `"case.fail"`) {
+		t.Errorf("fail event missing:\n%s", buf.String())
+	}
+}
+
+func TestNDJSONReporter_EmitsFixtureLifecycleAtVerboseAll(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewNDJSONReporter(&buf, VerboseAll)
+	r.Emit(Event{Type: EventFixtureStart, FixtureType: "compose"})
+	r.Emit(Event{Type: EventFixtureReady, FixtureType: "compose"})
+	r.Emit(Event{Type: EventFixtureTeardown, FixtureType: "compose"})
+
+	out := buf.String()
+	for _, want := range []string{`"fixture.start"`, `"fixture.ready"`, `"fixture.teardown"`} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("expected %s in NDJSON output:\n%s", want, out)
+		}
+	}
+}
+
+func TestNDJSONReporter_EmitsGCXExecAtVerboseCmd(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewNDJSONReporter(&buf, VerboseCmd)
+	r.Emit(Event{Type: EventGCXExec, Cmd: "gcx logs --query x"})
+	if !strings.Contains(buf.String(), `"gcx.exec"`) {
+		t.Fatalf("expected gcx.exec in NDJSON output:\n%s", buf.String())
+	}
+}
+
+func TestSplitSource(t *testing.T) {
+	cases := []struct {
+		in       string
+		wantFile string
+		wantLine int
+	}{
+		{"a.yaml:42", "a.yaml", 42},
+		{"a.yaml", "a.yaml", 0},
+		{"path/with/colon:x/a.yaml:7", "path/with/colon:x/a.yaml", 7},
+		{"a.yaml:notanint", "a.yaml:notanint", 0},
+		{"", "", 0},
+	}
+	for _, tc := range cases {
+		f, n := splitSource(tc.in)
+		if f != tc.wantFile || n != tc.wantLine {
+			t.Errorf("splitSource(%q): got (%q, %d), want (%q, %d)", tc.in, f, n, tc.wantFile, tc.wantLine)
+		}
+	}
+}

--- a/report/text.go
+++ b/report/text.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -40,7 +41,7 @@ func NewTextReporter(w io.Writer, v Verbosity) *TextReporter {
 	return &TextReporter{
 		w:          w,
 		v:          v,
-		ghaEnabled: os.Getenv("GITHUB_ACTIONS") == "true",
+		ghaEnabled: ghaAnnotationsEnabled(),
 		knownErrAt: make(map[string]struct{}),
 	}
 }
@@ -140,7 +141,7 @@ func (r *TextReporter) emitGHAAnnotation(e Event) {
 		msg = "OATS assertion failed"
 	}
 	msg = ghaEscape(msg)
-	file = ghaEscapeProp(file)
+	file = ghaEscapeProp(relToWorkspace(file))
 	if line > 0 {
 		r.write("::error file=%s,line=%d::%s\n", file, line, msg)
 	} else {
@@ -202,6 +203,38 @@ func durationOr(e Event, fallback time.Duration) time.Duration {
 		return time.Duration(e.DurationMs) * time.Millisecond
 	}
 	return fallback.Round(time.Millisecond)
+}
+
+// ghaAnnotationsEnabled reports whether to emit GitHub Actions ::error::
+// annotations. They are on by default inside GitHub Actions, but can be turned
+// off with OATS_GHA_ANNOTATIONS=false (also 0/no/off) for anyone who prefers
+// the plain text output without inline PR annotations.
+func ghaAnnotationsEnabled() bool {
+	if os.Getenv("GITHUB_ACTIONS") != "true" {
+		return false
+	}
+	switch strings.ToLower(os.Getenv("OATS_GHA_ANNOTATIONS")) {
+	case "false", "0", "no", "off":
+		return false
+	}
+	return true
+}
+
+// relToWorkspace makes an absolute path repo-relative for GitHub annotations.
+// GitHub attaches file= annotations by workspace-relative path, so an absolute
+// path like /home/runner/work/<repo>/<repo>/foo/case.yaml must become
+// foo/case.yaml to land on the file in the PR. No-op when GITHUB_WORKSPACE is
+// unset, the path is already relative, or the path lies outside the workspace.
+func relToWorkspace(file string) string {
+	ws := os.Getenv("GITHUB_WORKSPACE")
+	if ws == "" || !filepath.IsAbs(file) {
+		return file
+	}
+	rel, err := filepath.Rel(ws, file)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		return file
+	}
+	return rel
 }
 
 // splitSource splits "path/to/file.yaml:42" into (file, line). When no line

--- a/report/text.go
+++ b/report/text.go
@@ -1,0 +1,228 @@
+package report
+
+import (
+	"fmt"
+	"io"
+	"os"
+	"strings"
+	"time"
+)
+
+// write swallows write errors on purpose: a downstream pipe that died
+// should not crash the runner, and the exit status still reflects the test
+// outcome.
+func (r *TextReporter) write(format string, args ...any) {
+	_, _ = fmt.Fprintf(r.w, format, args...)
+}
+
+// TextReporter is the default Reporter. It emits compact text suitable for
+// both humans and agents: silent on success at default verbosity, detailed
+// per-failure blocks, and one summary line per run.
+//
+// When GITHUB_ACTIONS is set in the environment, failures are additionally
+// emitted as ::error::file=...,line=...:: annotations so reviewers see them
+// inline on the PR diff. The annotation channel is a thin pass-through over
+// the same failure events that drive the human-readable blocks — no
+// duplicate accounting, no separate sink.
+type TextReporter struct {
+	w          io.Writer
+	v          Verbosity
+	ghaEnabled bool
+	runStart   time.Time
+	pass       int
+	fail       int
+	skip       int
+	failBlocks []string // buffered "FAIL ..." blocks, flushed at run.end
+	knownErrAt map[string]struct{}
+}
+
+func NewTextReporter(w io.Writer, v Verbosity) *TextReporter {
+	return &TextReporter{
+		w:          w,
+		v:          v,
+		ghaEnabled: os.Getenv("GITHUB_ACTIONS") == "true",
+		knownErrAt: make(map[string]struct{}),
+	}
+}
+
+func (r *TextReporter) Emit(e Event) {
+	switch e.Type {
+	case EventRunStart:
+		r.resetRunState()
+		r.runStart = nonZeroOrNow(e.Ts)
+	case EventRunEnd:
+		r.flushRunEnd(e)
+	case EventCasePass:
+		r.pass++
+		if r.v >= VerbosePasses {
+			r.write("PASS %s\n", e.Case)
+		}
+	case EventCaseSkip:
+		r.skip++
+		if r.v >= VerbosePasses {
+			r.write("SKIP %s\n", e.Case)
+		}
+	case EventAssertFail:
+		r.recordFailure(e)
+	case EventCaseFail:
+		r.fail++
+	case EventGCXExec:
+		if r.v >= VerboseCmd {
+			r.write("  $ %s\n", e.Cmd)
+		}
+	case EventFixtureStart, EventFixtureReady, EventFixtureTeardown:
+		if r.v >= VerboseAll {
+			r.write("[fixture %s] %s (%dms)\n", e.FixtureType, e.Type, e.DurationMs)
+		}
+	}
+}
+
+func (r *TextReporter) Close() error { return nil }
+
+func (r *TextReporter) resetRunState() {
+	r.pass = 0
+	r.fail = 0
+	r.skip = 0
+	r.failBlocks = nil
+	r.knownErrAt = make(map[string]struct{})
+}
+
+func (r *TextReporter) recordFailure(e Event) {
+	var b strings.Builder
+	src := e.Source
+	if src == "" {
+		src = "(unknown source)"
+	}
+	fmt.Fprintf(&b, "FAIL %s  %s\n", e.Case, src)
+	if e.Msg != "" {
+		fmt.Fprintf(&b, "  %s\n", e.Msg)
+	}
+	if e.Cmd != "" {
+		fmt.Fprintf(&b, "  $ %s\n", e.Cmd)
+	}
+	if e.StdoutExcerpt != "" {
+		fmt.Fprintf(&b, "  stdout: %s\n", e.StdoutExcerpt)
+	}
+	r.failBlocks = append(r.failBlocks, b.String())
+
+	if r.ghaEnabled {
+		r.emitGHAAnnotation(e)
+	}
+}
+
+func (r *TextReporter) emitGHAAnnotation(e Event) {
+	if e.Source == "" {
+		const key = "(unknown source):0"
+		if _, dup := r.knownErrAt[key]; dup {
+			return
+		}
+		r.knownErrAt[key] = struct{}{}
+
+		msg := e.Msg
+		if msg == "" {
+			msg = "OATS assertion failed"
+		}
+		r.write("::error::%s\n", ghaEscape(msg))
+		return
+	}
+
+	file, line := splitSource(e.Source)
+	// Suppress duplicate annotations for the same source position so a case
+	// with N substring failures does not flood the PR diff.
+	key := fmt.Sprintf("%s:%d", file, line)
+	if _, dup := r.knownErrAt[key]; dup {
+		return
+	}
+	r.knownErrAt[key] = struct{}{}
+
+	msg := e.Msg
+	if msg == "" {
+		msg = "OATS assertion failed"
+	}
+	msg = ghaEscape(msg)
+	file = ghaEscapeProp(file)
+	if line > 0 {
+		r.write("::error file=%s,line=%d::%s\n", file, line, msg)
+	} else {
+		r.write("::error file=%s::%s\n", file, msg)
+	}
+}
+
+// ghaEscape percent-encodes a workflow-command message body. GitHub requires
+// %, CR and LF to be encoded or the annotation truncates at the first newline
+// (failures often carry multi-line HTTP bodies or stderr excerpts).
+func ghaEscape(s string) string {
+	s = strings.ReplaceAll(s, "%", "%25")
+	s = strings.ReplaceAll(s, "\r", "%0D")
+	s = strings.ReplaceAll(s, "\n", "%0A")
+	return s
+}
+
+// ghaEscapeProp percent-encodes a workflow-command property value such as the
+// file= path. Properties carry the message rules plus : and , which would
+// otherwise be read as property delimiters (file paths can contain colons —
+// see splitSource).
+func ghaEscapeProp(s string) string {
+	s = ghaEscape(s)
+	s = strings.ReplaceAll(s, ":", "%3A")
+	s = strings.ReplaceAll(s, ",", "%2C")
+	return s
+}
+
+func (r *TextReporter) flushRunEnd(e Event) {
+	// Failure blocks first so the summary line is the final thing the reader
+	// sees — useful for both humans (scroll to bottom) and CI logs (tail).
+	for _, b := range r.failBlocks {
+		r.write("\n")
+		r.write("%s", b)
+	}
+
+	total := r.pass + r.fail + r.skip
+	duration := durationOr(e, time.Since(r.runStart))
+	switch {
+	case r.fail == 0 && r.skip == 0:
+		r.write("\nPASS %d/%d in %s\n", r.pass, total, duration)
+	case r.fail == 0:
+		r.write("\nPASS %d/%d (%d skipped) in %s\n", r.pass, total, r.skip, duration)
+	default:
+		r.write("\nFAIL %d/%d (%d failed, %d skipped) in %s\n",
+			r.pass, total, r.fail, r.skip, duration)
+	}
+}
+
+func nonZeroOrNow(t time.Time) time.Time {
+	if t.IsZero() {
+		return time.Now()
+	}
+	return t
+}
+
+func durationOr(e Event, fallback time.Duration) time.Duration {
+	if e.DurationMs > 0 {
+		return time.Duration(e.DurationMs) * time.Millisecond
+	}
+	return fallback.Round(time.Millisecond)
+}
+
+// splitSource splits "path/to/file.yaml:42" into (file, line). When no line
+// number is present (or the suffix is non-numeric), line is zero and file is
+// the whole input. The contract for callers is "best effort": annotations
+// fall back to file-only when a line number cannot be derived.
+func splitSource(src string) (string, int) {
+	if src == "" {
+		return "", 0
+	}
+	idx := strings.LastIndex(src, ":")
+	if idx < 0 {
+		return src, 0
+	}
+	suffix := src[idx+1:]
+	n := 0
+	for _, c := range suffix {
+		if c < '0' || c > '9' {
+			return src, 0
+		}
+		n = n*10 + int(c-'0')
+	}
+	return src[:idx], n
+}

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -28,9 +28,6 @@ import (
 
 var defaultHTTPClient = &http.Client{Timeout: 10 * time.Second}
 
-// userAgent identifies inline-otlp seed traffic to the receiving backend.
-const userAgent = "oats-seed"
-
 // jsonString renders s as a JSON string literal (quotes included), escaped per
 // JSON rules. Payloads are assembled with fmt.Sprintf, so any field carrying
 // user-supplied text (service names, span/metric names, log bodies) must go
@@ -82,6 +79,19 @@ type Metric struct {
 type Sender struct {
 	OTLPEndpoint string
 	Client       *http.Client
+	// Version is the OATS version used to build the User-Agent. When empty the
+	// User-Agent is bare "oats"; the runner sets it so seed traffic is
+	// identifiable to the receiving backend as "oats/<version>".
+	Version string
+}
+
+// userAgent identifies inline-otlp seed traffic as "oats/<version>", or bare
+// "oats" when the version is unset.
+func (s *Sender) userAgent() string {
+	if s.Version == "" {
+		return "oats"
+	}
+	return "oats/" + s.Version
 }
 
 func (s *Sender) httpClient() *http.Client {
@@ -217,7 +227,7 @@ func (s *Sender) post(ctx context.Context, path, body string) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
-	req.Header.Set("User-Agent", userAgent)
+	req.Header.Set("User-Agent", s.userAgent())
 	resp, err := s.httpClient().Do(req)
 	if err != nil {
 		return err

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
@@ -26,6 +27,19 @@ import (
 )
 
 var defaultHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// userAgent identifies inline-otlp seed traffic to the receiving backend.
+const userAgent = "oats-seed"
+
+// jsonString renders s as a JSON string literal (quotes included), escaped per
+// JSON rules. Payloads are assembled with fmt.Sprintf, so any field carrying
+// user-supplied text (service names, span/metric names, log bodies) must go
+// through this rather than %q: Go's %q is close to JSON but diverges for a few
+// escapes (\a, \v) and invalid UTF-8, which would emit a non-JSON document.
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
 
 // Payload describes one inline-otlp seed declaration as it arrives from a
 // case yaml. All three signal slices are optional; emitting only the ones
@@ -120,21 +134,21 @@ func (s *Sender) sendTrace(ctx context.Context, t Trace, now time.Time) error {
 	body := fmt.Sprintf(`{
   "resourceSpans": [{
     "resource": {"attributes": [
-      {"key":"service.name","value":{"stringValue":%q}}
+      {"key":"service.name","value":{"stringValue":%s}}
     ]},
     "scopeSpans": [{
       "scope": {"name":"oats-inline-seed"},
       "spans": [{
         "traceId": %q,
         "spanId": %q,
-        "name": %q,
+        "name": %s,
         "kind": %d,
         "startTimeUnixNano": "%d",
         "endTimeUnixNano": "%d"
       }]
     }]
   }]
-}`, t.Service, mustRandHex(16), mustRandHex(8), t.Span.Name, kind, start, end)
+}`, jsonString(t.Service), mustRandHex(16), mustRandHex(8), jsonString(t.Span.Name), kind, start, end)
 	return s.post(ctx, "/v1/traces", body)
 }
 
@@ -150,19 +164,19 @@ func (s *Sender) sendLog(ctx context.Context, l Log, now time.Time) error {
 	body := fmt.Sprintf(`{
   "resourceLogs": [{
     "resource": {"attributes": [
-      {"key":"service.name","value":{"stringValue":%q}}
+      {"key":"service.name","value":{"stringValue":%s}}
     ]},
     "scopeLogs": [{
       "scope": {"name":"oats-inline-seed"},
       "logRecords": [{
         "timeUnixNano": "%d",
         "severityNumber": %d,
-        "severityText": %q,
-        "body": {"stringValue": %q}
+        "severityText": %s,
+        "body": {"stringValue": %s}
       }]
     }]
   }]
-}`, l.Service, now.UnixNano(), sev, sevText, l.Body)
+}`, jsonString(l.Service), now.UnixNano(), sev, jsonString(sevText), jsonString(l.Body))
 	return s.post(ctx, "/v1/logs", body)
 }
 
@@ -172,12 +186,12 @@ func (s *Sender) sendMetric(ctx context.Context, m Metric, now time.Time) error 
 	body := fmt.Sprintf(`{
   "resourceMetrics": [{
     "resource": {"attributes": [
-      {"key":"service.name","value":{"stringValue":%q}}
+      {"key":"service.name","value":{"stringValue":%s}}
     ]},
     "scopeMetrics": [{
       "scope": {"name":"oats-inline-seed"},
       "metrics": [{
-        "name": %q,
+        "name": %s,
         "sum": {
           "isMonotonic": true,
           "aggregationTemporality": 2,
@@ -190,7 +204,7 @@ func (s *Sender) sendMetric(ctx context.Context, m Metric, now time.Time) error 
       }]
     }]
   }]
-}`, m.Service, m.Name, start, end, m.Value)
+}`, jsonString(m.Service), jsonString(m.Name), start, end, m.Value)
 	return s.post(ctx, "/v1/metrics", body)
 }
 
@@ -203,6 +217,7 @@ func (s *Sender) post(ctx context.Context, path, body string) error {
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("User-Agent", userAgent)
 	resp, err := s.httpClient().Do(req)
 	if err != nil {
 		return err

--- a/seed/seed.go
+++ b/seed/seed.go
@@ -1,0 +1,234 @@
+// Package seed pushes known OTLP payloads into a running observability stack.
+//
+// The "inline-otlp" seed mode lets a case yaml carry its own data instead of
+// booting an instrumented example app. This decouples gcx-contract tests from
+// SDK behaviour: a case that wants to assert "gcx returns the trace I just
+// pushed" can declare the trace inline, eliminating an entire layer of
+// causation.
+//
+// The wire format is OTLP/HTTP JSON, which every supported backend accepts
+// without an SDK on the test runner's side. We hand-write the JSON rather
+// than pull in the OTel Go SDK because (a) the payloads are small and
+// (b) we want the test author to see exactly what was sent when an assertion
+// fails — no exporter middleware in between.
+package seed
+
+import (
+	"bytes"
+	"context"
+	"crypto/rand"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+	"time"
+)
+
+var defaultHTTPClient = &http.Client{Timeout: 10 * time.Second}
+
+// Payload describes one inline-otlp seed declaration as it arrives from a
+// case yaml. All three signal slices are optional; emitting only the ones
+// the case cares about keeps inline payloads short.
+type Payload struct {
+	Traces  []Trace
+	Logs    []Log
+	Metrics []Metric
+}
+
+type Trace struct {
+	Service string
+	Span    SpanFields
+}
+
+type SpanFields struct {
+	Name string
+	// Kind defaults to 1 (SPAN_KIND_INTERNAL) when zero.
+	Kind int
+	// Duration defaults to 200ms when zero.
+	Duration time.Duration
+}
+
+type Log struct {
+	Service        string
+	Body           string
+	SeverityNumber int    // defaults to 9 (INFO) when zero
+	SeverityText   string // defaults to "INFO" when empty
+}
+
+type Metric struct {
+	Service string
+	Name    string
+	Value   int64
+}
+
+// Sender pushes a Payload at an OTLP/HTTP endpoint (e.g. http://localhost:4318).
+// The endpoint is the base URL — the canonical /v1/{traces,logs,metrics} paths
+// are appended internally.
+type Sender struct {
+	OTLPEndpoint string
+	Client       *http.Client
+}
+
+func (s *Sender) httpClient() *http.Client {
+	if s.Client != nil {
+		return s.Client
+	}
+	return defaultHTTPClient
+}
+
+// Send pushes all signals declared in p. Returns the first error encountered,
+// but processes signals in a fixed order (traces, logs, metrics) so that a
+// partial send leaves the backend in a predictable state for assertions.
+// Cancelling ctx aborts in-flight and remaining requests so seeding does not
+// outlive a cancelled run.
+func (s *Sender) Send(ctx context.Context, p Payload) error {
+	if s.OTLPEndpoint == "" {
+		return fmt.Errorf("seed: OTLPEndpoint is empty")
+	}
+	now := time.Now()
+	for _, t := range p.Traces {
+		if err := s.sendTrace(ctx, t, now); err != nil {
+			return fmt.Errorf("seed traces: %w", err)
+		}
+	}
+	for _, l := range p.Logs {
+		if err := s.sendLog(ctx, l, now); err != nil {
+			return fmt.Errorf("seed logs: %w", err)
+		}
+	}
+	for _, m := range p.Metrics {
+		if err := s.sendMetric(ctx, m, now); err != nil {
+			return fmt.Errorf("seed metrics: %w", err)
+		}
+	}
+	return nil
+}
+
+func (s *Sender) sendTrace(ctx context.Context, t Trace, now time.Time) error {
+	dur := t.Span.Duration
+	if dur == 0 {
+		dur = 200 * time.Millisecond
+	}
+	kind := t.Span.Kind
+	if kind == 0 {
+		kind = 1
+	}
+	end := now.UnixNano()
+	start := now.Add(-dur).UnixNano()
+
+	body := fmt.Sprintf(`{
+  "resourceSpans": [{
+    "resource": {"attributes": [
+      {"key":"service.name","value":{"stringValue":%q}}
+    ]},
+    "scopeSpans": [{
+      "scope": {"name":"oats-inline-seed"},
+      "spans": [{
+        "traceId": %q,
+        "spanId": %q,
+        "name": %q,
+        "kind": %d,
+        "startTimeUnixNano": "%d",
+        "endTimeUnixNano": "%d"
+      }]
+    }]
+  }]
+}`, t.Service, mustRandHex(16), mustRandHex(8), t.Span.Name, kind, start, end)
+	return s.post(ctx, "/v1/traces", body)
+}
+
+func (s *Sender) sendLog(ctx context.Context, l Log, now time.Time) error {
+	sev := l.SeverityNumber
+	if sev == 0 {
+		sev = 9
+	}
+	sevText := l.SeverityText
+	if sevText == "" {
+		sevText = "INFO"
+	}
+	body := fmt.Sprintf(`{
+  "resourceLogs": [{
+    "resource": {"attributes": [
+      {"key":"service.name","value":{"stringValue":%q}}
+    ]},
+    "scopeLogs": [{
+      "scope": {"name":"oats-inline-seed"},
+      "logRecords": [{
+        "timeUnixNano": "%d",
+        "severityNumber": %d,
+        "severityText": %q,
+        "body": {"stringValue": %q}
+      }]
+    }]
+  }]
+}`, l.Service, now.UnixNano(), sev, sevText, l.Body)
+	return s.post(ctx, "/v1/logs", body)
+}
+
+func (s *Sender) sendMetric(ctx context.Context, m Metric, now time.Time) error {
+	end := now.UnixNano()
+	start := now.Add(-time.Second).UnixNano()
+	body := fmt.Sprintf(`{
+  "resourceMetrics": [{
+    "resource": {"attributes": [
+      {"key":"service.name","value":{"stringValue":%q}}
+    ]},
+    "scopeMetrics": [{
+      "scope": {"name":"oats-inline-seed"},
+      "metrics": [{
+        "name": %q,
+        "sum": {
+          "isMonotonic": true,
+          "aggregationTemporality": 2,
+          "dataPoints": [{
+            "startTimeUnixNano": "%d",
+            "timeUnixNano": "%d",
+            "asInt": "%d"
+          }]
+        }
+      }]
+    }]
+  }]
+}`, m.Service, m.Name, start, end, m.Value)
+	return s.post(ctx, "/v1/metrics", body)
+}
+
+func (s *Sender) post(ctx context.Context, path, body string) error {
+	// Trim a trailing slash so a user-supplied endpoint like "http://h:4318/"
+	// doesn't produce "...//v1/traces", which some OTLP receivers reject.
+	endpoint := strings.TrimRight(s.OTLPEndpoint, "/")
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, endpoint+path, bytes.NewBufferString(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := s.httpClient().Do(req)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = resp.Body.Close() }()
+	if resp.StatusCode >= 300 {
+		data, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("%s: %s\n%s", path, resp.Status, data)
+	}
+	return nil
+}
+
+func randHex(nBytes int) (string, error) {
+	buf := make([]byte, nBytes)
+	if _, err := rand.Read(buf); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(buf), nil
+}
+
+func mustRandHex(nBytes int) string {
+	s, err := randHex(nBytes)
+	if err != nil {
+		// Extremely rare; fall back to a stable all-zero ID rather than panic so
+		// the run fails, if at all, through normal backend/query behavior.
+		return strings.Repeat("0", nBytes*2)
+	}
+	return s
+}

--- a/seed/seed_test.go
+++ b/seed/seed_test.go
@@ -77,6 +77,48 @@ func TestSender_SendTracesLogsMetrics(t *testing.T) {
 	}
 }
 
+func TestSender_EscapesSpecialCharacters(t *testing.T) {
+	// Values a case author could plausibly write that Go's %q renders as
+	// non-JSON (\v, a control char) or that need escaping (" \ newline tab).
+	// Every captured payload must parse as JSON and round-trip the value.
+	srv, h := newRecorder()
+	defer srv.Close()
+
+	tricky := "a\"b\\c\nd\te\vf\x01g"
+	s := &Sender{OTLPEndpoint: srv.URL}
+	err := s.Send(context.Background(), Payload{
+		Traces:  []Trace{{Service: tricky, Span: SpanFields{Name: tricky}}},
+		Logs:    []Log{{Service: tricky, Body: tricky, SeverityText: tricky}},
+		Metrics: []Metric{{Service: tricky, Name: tricky, Value: 1}},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	for _, path := range []string{"/v1/traces", "/v1/logs", "/v1/metrics"} {
+		if !json.Valid(h.requests[path]) {
+			t.Errorf("payload at %s is not valid JSON:\n%s", path, h.requests[path])
+		}
+	}
+
+	// Spot-check the value round-trips intact via the trace span name.
+	var traces struct {
+		ResourceSpans []struct {
+			ScopeSpans []struct {
+				Spans []struct {
+					Name string `json:"name"`
+				} `json:"spans"`
+			} `json:"scopeSpans"`
+		} `json:"resourceSpans"`
+	}
+	if err := json.Unmarshal(h.requests["/v1/traces"], &traces); err != nil {
+		t.Fatalf("unmarshal traces: %v", err)
+	}
+	if got := traces.ResourceSpans[0].ScopeSpans[0].Spans[0].Name; got != tricky {
+		t.Errorf("span name round-trip: got %q, want %q", got, tricky)
+	}
+}
+
 func TestSender_EmptyEndpointFailsLoudly(t *testing.T) {
 	s := &Sender{}
 	if err := s.Send(context.Background(), Payload{}); err == nil {

--- a/seed/seed_test.go
+++ b/seed/seed_test.go
@@ -1,0 +1,139 @@
+package seed
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"sync"
+	"testing"
+)
+
+type recordingHandler struct {
+	mu       sync.Mutex
+	requests map[string][]byte
+}
+
+func (h *recordingHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	h.mu.Lock()
+	h.requests[r.URL.Path] = body
+	h.mu.Unlock()
+	w.WriteHeader(http.StatusOK)
+}
+
+func newRecorder() (*httptest.Server, *recordingHandler) {
+	h := &recordingHandler{requests: make(map[string][]byte)}
+	return httptest.NewServer(h), h
+}
+
+func TestSender_SendTracesLogsMetrics(t *testing.T) {
+	srv, h := newRecorder()
+	defer srv.Close()
+
+	s := &Sender{OTLPEndpoint: srv.URL}
+	err := s.Send(context.Background(), Payload{
+		Traces: []Trace{{
+			Service: "svc-a",
+			Span:    SpanFields{Name: "do-thing"},
+		}},
+		Logs: []Log{{
+			Service: "svc-a",
+			Body:    "hello",
+		}},
+		Metrics: []Metric{{
+			Service: "svc-a",
+			Name:    "things_total",
+			Value:   42,
+		}},
+	})
+	if err != nil {
+		t.Fatalf("Send: %v", err)
+	}
+
+	if _, ok := h.requests["/v1/traces"]; !ok {
+		t.Error("traces endpoint not hit")
+	}
+	if _, ok := h.requests["/v1/logs"]; !ok {
+		t.Error("logs endpoint not hit")
+	}
+	if _, ok := h.requests["/v1/metrics"]; !ok {
+		t.Error("metrics endpoint not hit")
+	}
+
+	for _, want := range []struct {
+		path, needle string
+	}{
+		{"/v1/traces", "do-thing"},
+		{"/v1/traces", "svc-a"},
+		{"/v1/logs", "hello"},
+		{"/v1/metrics", "things_total"},
+	} {
+		if !strings.Contains(string(h.requests[want.path]), want.needle) {
+			t.Errorf("payload at %s missing %q:\n%s", want.path, want.needle, h.requests[want.path])
+		}
+	}
+}
+
+func TestSender_EmptyEndpointFailsLoudly(t *testing.T) {
+	s := &Sender{}
+	if err := s.Send(context.Background(), Payload{}); err == nil {
+		t.Fatal("expected an error for empty endpoint")
+	}
+}
+
+func TestSender_BackendErrorPropagates(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = w.Write([]byte("rejected"))
+	}))
+	defer srv.Close()
+
+	s := &Sender{OTLPEndpoint: srv.URL}
+	err := s.Send(context.Background(), Payload{Traces: []Trace{{Service: "x", Span: SpanFields{Name: "y"}}}})
+	if err == nil {
+		t.Fatal("expected an error from 400 response")
+	}
+	if !strings.Contains(err.Error(), "rejected") {
+		t.Errorf("error should include backend body, got: %v", err)
+	}
+}
+
+func TestSender_SpanDefaultsApply(t *testing.T) {
+	srv, h := newRecorder()
+	defer srv.Close()
+
+	s := &Sender{OTLPEndpoint: srv.URL}
+	err := s.Send(context.Background(), Payload{Traces: []Trace{{
+		Service: "svc",
+		Span:    SpanFields{Name: "n"},
+	}}})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Decode just enough to verify defaults made it into the wire payload.
+	var parsed struct {
+		ResourceSpans []struct {
+			ScopeSpans []struct {
+				Spans []struct {
+					Kind              int    `json:"kind"`
+					StartTimeUnixNano string `json:"startTimeUnixNano"`
+					EndTimeUnixNano   string `json:"endTimeUnixNano"`
+				} `json:"spans"`
+			} `json:"scopeSpans"`
+		} `json:"resourceSpans"`
+	}
+	if err := json.Unmarshal(h.requests["/v1/traces"], &parsed); err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	span := parsed.ResourceSpans[0].ScopeSpans[0].Spans[0]
+	if span.Kind != 1 {
+		t.Errorf("Kind default: got %d, want 1", span.Kind)
+	}
+	if span.StartTimeUnixNano == "" || span.EndTimeUnixNano == "" {
+		t.Errorf("timestamps empty: %+v", span)
+	}
+}

--- a/signalcmd/signalcmd.go
+++ b/signalcmd/signalcmd.go
@@ -1,0 +1,173 @@
+// Package signalcmd translates a single case assertion into the gcx
+// command line that will execute the corresponding query.
+//
+// One function per signal type. Each returns []string suitable for handing
+// to engine.GCX.Execute: positional args only, no --context (engine prepends
+// that), no datasource flag (resolved from the gcx config context).
+//
+// The output format is fixed to gcx's default "agents" text mode for
+// substring assertions; JSON (-o json) for assertions that need a
+// structured value extracted (metrics' `value` key).
+package signalcmd
+
+import (
+	"strings"
+	"time"
+
+	"github.com/grafana/oats/casefile"
+)
+
+// Defaults applied when a case does not pin its own values.
+const (
+	DefaultSince = 10 * time.Minute
+)
+
+// Traces builds the gcx args for a TraceAssertion.
+func Traces(a casefile.TraceAssertion, since time.Duration) []string {
+	if since <= 0 {
+		since = DefaultSince
+	}
+	args := []string{
+		"traces", "search",
+		"--since", since.String(),
+	}
+	if len(a.MatchSpans) > 0 {
+		args = append(args, "-o", "json")
+	}
+	args = append(args, a.TraceQL)
+	return args
+}
+
+// TraceGet builds the gcx args to retrieve one trace by ID as OTLP-shaped JSON.
+func TraceGet(traceID string, since time.Duration) []string {
+	if since <= 0 {
+		since = DefaultSince
+	}
+	return []string{
+		"traces", "get",
+		"--since", since.String(),
+		"-o", "json",
+		traceID,
+	}
+}
+
+// Logs builds the gcx args for a LogAssertion.
+func Logs(a casefile.LogAssertion, since time.Duration) []string {
+	if since <= 0 {
+		since = DefaultSince
+	}
+	args := []string{
+		"logs", "query",
+		"--since", since.String(),
+	}
+	if len(a.Match) > 0 {
+		args = append(args, "-o", "json")
+	}
+	args = append(args, a.LogQL)
+	return args
+}
+
+// Metrics builds the gcx args for a MetricAssertion. When the assertion
+// declares a numeric `value` comparison we ask gcx for JSON so the runner
+// can parse the actual value out; otherwise the default agent text format
+// is enough for substring matching.
+func Metrics(a casefile.MetricAssertion, since time.Duration) []string {
+	if since <= 0 {
+		since = DefaultSince
+	}
+	args := []string{
+		"metrics", "query",
+		"--since", since.String(),
+	}
+	if a.Value != "" || len(a.Match) > 0 {
+		args = append(args, "-o", "json")
+	}
+	args = append(args, a.PromQL)
+	return args
+}
+
+// Profiles builds the gcx args for a ProfileAssertion.
+func Profiles(a casefile.ProfileAssertion, since time.Duration) []string {
+	if since <= 0 {
+		since = DefaultSince
+	}
+	profileType, expr := splitProfileQuery(a.Query)
+	args := []string{
+		"profiles", "query",
+		"--since", since.String(),
+	}
+	if len(a.Match) > 0 {
+		args = append(args, "-o", "json")
+	}
+	if profileType != "" {
+		args = append(args, "--profile-type", profileType)
+	}
+	args = append(args, expr)
+	return args
+}
+
+func splitProfileQuery(query string) (profileType string, expr string) {
+	q := strings.TrimSpace(query)
+	if q == "" {
+		return "", "{}"
+	}
+	if i := strings.Index(q, "{"); i >= 0 {
+		profileType = strings.TrimSpace(q[:i])
+		expr = strings.TrimSpace(q[i:])
+		if expr == "" {
+			expr = "{}"
+		}
+		return profileType, expr
+	}
+	if strings.Contains(q, ":") {
+		return q, "{}"
+	}
+	return "", q
+}
+
+// Render is a convenience used by the report layer to show the gcx
+// invocation in a FAIL block. It mirrors what a shell would print.
+func Render(args []string) string {
+	out := "gcx"
+	for _, a := range args {
+		out += " " + shellQuote(a)
+	}
+	return out
+}
+
+// shellQuote is intentionally tiny: TraceQL / PromQL / LogQL strings often
+// contain spaces and quotes that need to survive a copy-paste from a FAIL
+// block. We single-quote anything that's not "boring."
+func shellQuote(s string) string {
+	if s == "" {
+		return "''"
+	}
+	safe := true
+	for _, c := range s {
+		switch {
+		case c >= 'a' && c <= 'z':
+		case c >= 'A' && c <= 'Z':
+		case c >= '0' && c <= '9':
+		case c == '-' || c == '_' || c == '.' || c == '/' || c == ':' || c == '=':
+		default:
+			safe = false
+		}
+		if !safe {
+			break
+		}
+	}
+	if safe {
+		return s
+	}
+	// Single-quote and escape any embedded single quotes.
+	quoted := "'"
+	for _, c := range s {
+		if c == '\'' {
+			quoted += `'\''`
+		} else {
+			quoted += string(c)
+		}
+	}
+	quoted += "'"
+	return quoted
+}

--- a/signalcmd/signalcmd_test.go
+++ b/signalcmd/signalcmd_test.go
@@ -1,0 +1,148 @@
+package signalcmd
+
+import (
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/grafana/oats/casefile"
+)
+
+func TestTraces(t *testing.T) {
+	got := Traces(casefile.TraceAssertion{TraceQL: `{ span.http.route = "/x" }`}, 0)
+	want := []string{"traces", "search", "--since", "10m0s", `{ span.http.route = "/x" }`}
+	if !equal(got, want) {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+}
+
+func TestTraces_WithMatchAsksForJSON(t *testing.T) {
+	got := Traces(casefile.TraceAssertion{
+		TraceQL:    `{ span.http.route = "/x" }`,
+		MatchSpans: []casefile.MatchEntry{{Name: strPtr("GET /x")}},
+	}, 0)
+	if !contains(got, "-o", "json") {
+		t.Errorf("expected -o json in: %v", got)
+	}
+}
+
+func TestLogs(t *testing.T) {
+	got := Logs(casefile.LogAssertion{LogQL: `{service_name="x"}`}, 5*time.Minute)
+	want := []string{"logs", "query", "--since", "5m0s", `{service_name="x"}`}
+	if !equal(got, want) {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+}
+
+func TestLogs_WithMatchAsksForJSON(t *testing.T) {
+	got := Logs(casefile.LogAssertion{
+		LogQL: `{service_name="x"}`,
+		AssertionCommon: casefile.AssertionCommon{
+			Match: []casefile.MatchEntry{{Name: strPtr("line")}},
+		},
+	}, 5*time.Minute)
+	if !contains(got, "-o", "json") {
+		t.Errorf("expected -o json in: %v", got)
+	}
+}
+
+func TestMetrics_PromQLOnly(t *testing.T) {
+	got := Metrics(casefile.MetricAssertion{PromQL: "up"}, time.Minute)
+	want := []string{"metrics", "query", "--since", "1m0s", "up"}
+	if !equal(got, want) {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+}
+
+func TestMetrics_WithValueAsksForJSON(t *testing.T) {
+	got := Metrics(casefile.MetricAssertion{PromQL: "rate(x[1m])", Value: ">= 0"}, time.Minute)
+	// JSON output flag must appear before the positional PromQL.
+	if !contains(got, "-o", "json") {
+		t.Errorf("expected -o json in: %v", got)
+	}
+	if got[len(got)-1] != "rate(x[1m])" {
+		t.Errorf("PromQL should be last positional: %v", got)
+	}
+}
+
+func TestProfiles(t *testing.T) {
+	got := Profiles(casefile.ProfileAssertion{Query: "process_cpu:cpu:nanoseconds:cpu:nanoseconds{}"}, 0)
+	want := []string{"profiles", "query", "--since", "10m0s", "--profile-type", "process_cpu:cpu:nanoseconds:cpu:nanoseconds", "{}"}
+	if !equal(got, want) {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+}
+
+func TestProfiles_QueryWithoutSelectorDefaultsToEmptySelector(t *testing.T) {
+	got := Profiles(casefile.ProfileAssertion{Query: "process_cpu:cpu:nanoseconds:cpu:nanoseconds"}, 0)
+	want := []string{"profiles", "query", "--since", "10m0s", "--profile-type", "process_cpu:cpu:nanoseconds:cpu:nanoseconds", "{}"}
+	if !equal(got, want) {
+		t.Errorf("got %v\nwant %v", got, want)
+	}
+}
+
+func TestProfiles_WithMatchAsksForJSON(t *testing.T) {
+	got := Profiles(casefile.ProfileAssertion{
+		Query: "process_cpu:cpu:nanoseconds:cpu:nanoseconds{}",
+		AssertionCommon: casefile.AssertionCommon{
+			Match: []casefile.MatchEntry{{Name: strPtr("main")}},
+		},
+	}, 0)
+	if !contains(got, "-o", "json") {
+		t.Errorf("expected -o json in: %v", got)
+	}
+}
+
+func TestRender_QuotesSpecialChars(t *testing.T) {
+	args := []string{"traces", "search", `{ span.http.route = "/x" }`}
+	rendered := Render(args)
+	if !strings.HasPrefix(rendered, "gcx traces search '{") {
+		t.Errorf("complex arg should be single-quoted: %s", rendered)
+	}
+}
+
+func TestRender_LeavesBoringArgsBare(t *testing.T) {
+	args := []string{"metrics", "query", "--since", "10m"}
+	rendered := Render(args)
+	if rendered != "gcx metrics query --since 10m" {
+		t.Errorf("boring args should not be quoted: %s", rendered)
+	}
+}
+
+func TestRender_EscapesSingleQuote(t *testing.T) {
+	rendered := Render([]string{"echo", "it's"})
+	// Embedded single quote escaped as '\''
+	if !strings.Contains(rendered, `'\''`) {
+		t.Errorf("missing quote escape: %s", rendered)
+	}
+}
+
+func equal(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func contains(haystack []string, needles ...string) bool {
+	for i := 0; i+len(needles) <= len(haystack); i++ {
+		match := true
+		for j, n := range needles {
+			if haystack[i+j] != n {
+				match = false
+				break
+			}
+		}
+		if match {
+			return true
+		}
+	}
+	return false
+}
+
+func strPtr(s string) *string { return &s }

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -1,4 +1,4 @@
-// Package wait holds OATS v2's polling primitive: "keep trying until this
+// Package wait holds OATS's polling primitive: "keep trying until this
 // passes, or give up at the deadline."
 //
 // In v1 this was gomega.Eventually. v2 drops gomega, so wait provides the

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -1,0 +1,181 @@
+// Package wait holds OATS v2's polling primitive: "keep trying until this
+// passes, or give up at the deadline."
+//
+// In v1 this was gomega.Eventually. v2 drops gomega, so wait provides the
+// same shape (asserter callback + timeout + polling interval) without the
+// DSL. Failures are values, not panics; the runner decides how to render
+// them via the report package.
+//
+// Two modes:
+//
+//	Until — succeed once any iteration's assertion has no failures
+//	While — succeed only if every iteration's assertion has no failures
+//	        for the entire window (used for absence checks)
+package wait
+
+import (
+	"context"
+	"time"
+)
+
+// Defaults applied when the caller passes zero values.
+const (
+	DefaultTimeout  = 30 * time.Second
+	DefaultInterval = 500 * time.Millisecond
+)
+
+// Asserter is invoked on each poll. It returns the failures it observed —
+// an empty slice (or nil) means "the expectation held on this iteration."
+type Asserter[F any] func() []F
+
+// Options controls polling cadence. Timeout caps the total wall-clock spent
+// retrying. Interval is the gap between polls. Zero values get sensible
+// defaults (see DefaultTimeout / DefaultInterval).
+type Options struct {
+	Timeout  time.Duration
+	Interval time.Duration
+}
+
+// Result is what Until and While return. Iterations counts how many poll
+// attempts ran; LastFailures is the most recent failure set observed — nil on
+// success and when no asserter call ever reported failures (including a run
+// cancelled or stopped before any failure was observed). If any call did
+// report failures, those are returned even when the run was ultimately
+// cancelled or timed out.
+type Result[F any] struct {
+	OK           bool
+	Iterations   int
+	Elapsed      time.Duration
+	LastFailures []F
+}
+
+// Until polls the asserter until it returns no failures (success) or the
+// deadline elapses (failure). It runs the asserter at least once even when
+// the deadline has already passed.
+func Until[F any](ctx context.Context, opts Options, asserter Asserter[F]) Result[F] {
+	opts = withDefaults(opts)
+	start := time.Now()
+	deadline := start.Add(opts.Timeout)
+	var timer *time.Timer
+	defer func() { stopTimer(timer) }()
+
+	var last, lastFailures []F
+	iter := 0
+	for {
+		iter++
+		last = asserter()
+		if len(last) == 0 {
+			// A cancelled context must not be reported as success, even when
+			// the asserter passed — consistent with While. The asserter has
+			// still run at least once per contract. Preserve any failures seen
+			// on earlier iterations so the caller can still see what was
+			// failing right before cancellation (per Result's docstring).
+			if ctx.Err() != nil {
+				return Result[F]{OK: false, Iterations: iter, Elapsed: time.Since(start), LastFailures: lastFailures}
+			}
+			return Result[F]{OK: true, Iterations: iter, Elapsed: time.Since(start), LastFailures: nil}
+		}
+		lastFailures = last // remember the most recent non-empty failure set
+		if !time.Now().Before(deadline) {
+			return Result[F]{OK: false, Iterations: iter, Elapsed: time.Since(start), LastFailures: last}
+		}
+		if ctx.Err() != nil {
+			return Result[F]{OK: false, Iterations: iter, Elapsed: time.Since(start), LastFailures: last}
+		}
+		if !waitForNextPoll(ctx, &timer, sleepInterval(opts.Interval, deadline)) {
+			return Result[F]{OK: false, Iterations: iter, Elapsed: time.Since(start), LastFailures: last}
+		}
+	}
+}
+
+// While polls the asserter for the entire window, requiring no failures on
+// every iteration. Used for absence checks ("data we DON'T want must stay
+// absent for at least N seconds"). Reports the first failing iteration's
+// failures, if any.
+func While[F any](ctx context.Context, opts Options, asserter Asserter[F]) Result[F] {
+	opts = withDefaults(opts)
+	start := time.Now()
+	deadline := start.Add(opts.Timeout)
+	var timer *time.Timer
+	defer func() { stopTimer(timer) }()
+
+	iter := 0
+	for {
+		iter++
+		fails := asserter()
+		if len(fails) > 0 {
+			return Result[F]{OK: false, Iterations: iter, Elapsed: time.Since(start), LastFailures: fails}
+		}
+		if !time.Now().Before(deadline) {
+			return Result[F]{OK: true, Iterations: iter, Elapsed: time.Since(start), LastFailures: nil}
+		}
+		if ctx.Err() != nil {
+			return Result[F]{OK: false, Iterations: iter, Elapsed: time.Since(start), LastFailures: nil}
+		}
+		if !waitForNextPoll(ctx, &timer, sleepInterval(opts.Interval, deadline)) {
+			return Result[F]{OK: false, Iterations: iter, Elapsed: time.Since(start), LastFailures: nil}
+		}
+	}
+}
+
+func withDefaults(o Options) Options {
+	if o.Timeout <= 0 {
+		o.Timeout = DefaultTimeout
+	}
+	if o.Interval <= 0 {
+		o.Interval = DefaultInterval
+	}
+	return o
+}
+
+func sleepInterval(interval time.Duration, deadline time.Time) time.Duration {
+	remaining := time.Until(deadline)
+	if remaining <= 0 {
+		return 0
+	}
+	if remaining < interval {
+		return remaining
+	}
+	return interval
+}
+
+func waitForNextPoll(ctx context.Context, timer **time.Timer, d time.Duration) bool {
+	if d <= 0 {
+		return true
+	}
+	if *timer == nil {
+		*timer = time.NewTimer(d)
+	} else {
+		if !(*timer).Stop() {
+			select {
+			case <-(*timer).C:
+			default:
+			}
+		}
+		(*timer).Reset(d)
+	}
+	select {
+	case <-(*timer).C:
+		return true
+	case <-ctx.Done():
+		if !(*timer).Stop() {
+			select {
+			case <-(*timer).C:
+			default:
+			}
+		}
+		return false
+	}
+}
+
+func stopTimer(timer *time.Timer) {
+	if timer == nil {
+		return
+	}
+	if !timer.Stop() {
+		select {
+		case <-timer.C:
+		default:
+		}
+	}
+}

--- a/wait/wait.go
+++ b/wait/wait.go
@@ -51,7 +51,9 @@ type Result[F any] struct {
 
 // Until polls the asserter until it returns no failures (success) or the
 // deadline elapses (failure). It runs the asserter at least once even when
-// the deadline has already passed.
+// the deadline has already passed. Between polls it waits on ctx, so a
+// cancelled context — e.g. the CLI cancelling on Ctrl+C (SIGINT) — returns
+// promptly rather than sleeping out the interval.
 func Until[F any](ctx context.Context, opts Options, asserter Asserter[F]) Result[F] {
 	opts = withDefaults(opts)
 	start := time.Now()
@@ -91,7 +93,8 @@ func Until[F any](ctx context.Context, opts Options, asserter Asserter[F]) Resul
 // While polls the asserter for the entire window, requiring no failures on
 // every iteration. Used for absence checks ("data we DON'T want must stay
 // absent for at least N seconds"). Reports the first failing iteration's
-// failures, if any.
+// failures, if any. Like Until, it waits on ctx between polls, so a cancelled
+// context (e.g. Ctrl+C) returns promptly.
 func While[F any](ctx context.Context, opts Options, asserter Asserter[F]) Result[F] {
 	opts = withDefaults(opts)
 	start := time.Now()

--- a/wait/wait_test.go
+++ b/wait/wait_test.go
@@ -1,0 +1,158 @@
+package wait
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+)
+
+func TestUntil_SucceedsFirstTry(t *testing.T) {
+	r := Until[string](context.Background(), Options{Timeout: time.Second, Interval: 10 * time.Millisecond}, func() []string {
+		return nil
+	})
+	if !r.OK {
+		t.Errorf("expected OK, got %+v", r)
+	}
+	if r.Iterations != 1 {
+		t.Errorf("Iterations: got %d, want 1", r.Iterations)
+	}
+}
+
+func TestUntil_SucceedsAfterSeveralTries(t *testing.T) {
+	var n int32
+	r := Until[string](context.Background(), Options{Timeout: time.Second, Interval: 5 * time.Millisecond}, func() []string {
+		if atomic.AddInt32(&n, 1) < 3 {
+			return []string{"not yet"}
+		}
+		return nil
+	})
+	if !r.OK {
+		t.Fatalf("expected OK after retries, got %+v", r)
+	}
+	if r.Iterations != 3 {
+		t.Errorf("Iterations: got %d, want 3", r.Iterations)
+	}
+}
+
+func TestUntil_FailsAtDeadline(t *testing.T) {
+	start := time.Now()
+	r := Until[string](context.Background(), Options{Timeout: 30 * time.Millisecond, Interval: 5 * time.Millisecond}, func() []string {
+		return []string{"never passes"}
+	})
+	if r.OK {
+		t.Errorf("expected !OK, got %+v", r)
+	}
+	if len(r.LastFailures) == 0 {
+		t.Errorf("LastFailures should carry the last asserter output")
+	}
+	// Generous upper bound: guards against a runaway loop that ignores the
+	// deadline (which would be seconds), while tolerating CI scheduler jitter.
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("Until overshot timeout too far: %s", elapsed)
+	}
+}
+
+func TestUntil_RunsAtLeastOnceEvenWithTightDeadline(t *testing.T) {
+	// A tight deadline should still invoke the asserter at least once. The
+	// contract is "at least once," not "zero polls under short timeouts."
+	called := false
+	r := Until[string](context.Background(), Options{Timeout: 5 * time.Millisecond}, func() []string {
+		called = true
+		return []string{"x"}
+	})
+	if !called {
+		t.Error("asserter must be invoked at least once even under tight deadline")
+	}
+	if r.OK {
+		t.Errorf("expected !OK, got %+v", r)
+	}
+}
+
+func TestUntil_CancelledContextDoesNotPass(t *testing.T) {
+	// Even when the asserter passes, an already-cancelled context must not be
+	// reported as success — consistent with While.
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	called := false
+	r := Until[string](ctx, Options{Timeout: time.Second, Interval: 5 * time.Millisecond}, func() []string {
+		called = true
+		return nil // passes
+	})
+	if !called {
+		t.Error("asserter should still run once before honoring cancel")
+	}
+	if r.OK {
+		t.Errorf("cancelled context should not pass even when asserter succeeds: %+v", r)
+	}
+}
+
+func TestUntil_CancelPreservesEarlierFailures(t *testing.T) {
+	// Iterations fail, then the context is cancelled and the asserter passes.
+	// The run is not a success, and the earlier failures must be preserved so
+	// the caller can see what was failing before cancellation.
+	ctx, cancel := context.WithCancel(context.Background())
+	iter := 0
+	r := Until[string](ctx, Options{Timeout: time.Second, Interval: time.Millisecond}, func() []string {
+		iter++
+		if iter < 3 {
+			return []string{"boom"}
+		}
+		cancel()   // cancel, then report success on this poll
+		return nil // passes, but ctx is now cancelled
+	})
+	if r.OK {
+		t.Errorf("cancelled run should not pass: %+v", r)
+	}
+	if len(r.LastFailures) != 1 || r.LastFailures[0] != "boom" {
+		t.Errorf("expected earlier failures preserved on cancel, got %+v", r.LastFailures)
+	}
+}
+
+func TestWhile_HoldsForEntireWindow(t *testing.T) {
+	start := time.Now()
+	r := While[string](context.Background(), Options{Timeout: 30 * time.Millisecond, Interval: 5 * time.Millisecond}, func() []string {
+		return nil // never fails
+	})
+	if !r.OK {
+		t.Errorf("expected OK, got %+v", r)
+	}
+	if r.Iterations < 2 {
+		t.Errorf("expected multiple polls in 30ms with 5ms interval, got %d", r.Iterations)
+	}
+	// Generous upper bound: guards against a runaway loop that ignores the
+	// deadline (which would be seconds), while tolerating CI scheduler jitter.
+	if elapsed := time.Since(start); elapsed > 500*time.Millisecond {
+		t.Fatalf("While overshot timeout too far: %s", elapsed)
+	}
+}
+
+func TestWhile_FailsOnFirstFailure(t *testing.T) {
+	var n int32
+	r := While[string](context.Background(), Options{Timeout: 200 * time.Millisecond, Interval: 5 * time.Millisecond}, func() []string {
+		if atomic.AddInt32(&n, 1) > 3 {
+			return []string{"data appeared mid-window"}
+		}
+		return nil
+	})
+	if r.OK {
+		t.Fatalf("expected !OK on mid-window failure, got %+v", r)
+	}
+	if len(r.LastFailures) == 0 {
+		t.Errorf("LastFailures should describe the breach")
+	}
+}
+
+func TestUntil_ContextCancelStops(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+	r := Until[string](ctx, Options{Timeout: time.Second, Interval: 5 * time.Millisecond}, func() []string {
+		return []string{"x"}
+	})
+	if r.OK {
+		t.Errorf("cancelled context should not pass: %+v", r)
+	}
+	if r.Iterations == 0 {
+		t.Errorf("asserter should still run once before honoring cancel")
+	}
+}


### PR DESCRIPTION
Part **2/8** of splitting #334. Stacked on #368.

## What
Reusable, dependency-light primitives used by the runner: `wait` (Until/While polling), `assert` (signal assertions), `seed` (OTLP seeding), `report` (event/text/ndjson), `cache`, `engine` (executor interface), `signalcmd`.

## Depends on
#368 - now merged
