### PR TITLE
feat(discovery): derive fixture-boot groups (drop suites)

### DIFF
--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -1,0 +1,350 @@
+// Package discovery turns an oats-config.yaml + a collection of case yamls into
+// concrete run plans.
+//
+// In OATS v1, the runner walked the file system for any yaml carrying
+// "oats-schema-version" and ran whatever it found. The current format declares
+// the cases up front: oats-config.yaml lists case files (path globs). Each case
+// carries its own fixture; discovery groups cases that share one fixture into a
+// single plan so the (often expensive) fixture boots once and every case in the
+// group runs against it. Distinct plans are independent and may run in parallel
+// where fixture isolation allows. "oats list" prints the plans before "oats run"
+// executes them.
+package discovery
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/grafana/oats/casefile"
+	"go.yaml.in/yaml/v3"
+)
+
+// RootConfig is the parsed oats-config.yaml file. Field names mirror the YAML keys
+// directly so a misnamed key surfaces as a "field not defined" error from
+// the yaml decoder rather than a silent miss.
+type RootConfig struct {
+	Meta  Meta        `yaml:"meta"`
+	Cases []string    `yaml:"cases"` // path globs, relative to oats-config.yaml dir
+	Cache CacheConfig `yaml:"cache,omitempty"`
+
+	// SourceDir is the directory of the loaded oats-config.yaml. Case glob
+	// expressions resolve relative to it.
+	SourceDir string `yaml:"-"`
+}
+
+type Meta struct {
+	Version int `yaml:"version"`
+}
+
+type CacheConfig struct {
+	TTLDays int `yaml:"ttl_days,omitempty"` // zero → use runtime default
+}
+
+// SupportedVersion is the value of meta.version that this binary parses. It is
+// the single schema version for a v3 project: cases carry no version field of
+// their own.
+const SupportedVersion = 3
+
+// Load reads an oats-config.yaml from disk.
+func Load(path string) (*RootConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("discovery load %s: %w", path, err)
+	}
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true) // reject unknown keys
+	var cfg RootConfig
+	if err := dec.Decode(&cfg); err != nil {
+		return nil, fmt.Errorf("discovery parse %s: %w", path, err)
+	}
+	cfg.SourceDir = filepath.Dir(path)
+	if err := cfg.Validate(); err != nil {
+		return nil, err
+	}
+	return &cfg, nil
+}
+
+// Validate checks structural rules the yaml parser cannot. Called by Load;
+// exposed for tests that construct RootConfigs in memory.
+func (c *RootConfig) Validate() error {
+	if c.Meta.Version != SupportedVersion {
+		return fmt.Errorf("meta.version: expected %d, got %d", SupportedVersion, c.Meta.Version)
+	}
+	if len(c.Cases) == 0 {
+		return fmt.Errorf("cases: at least one case glob is required")
+	}
+	for i, path := range c.Cases {
+		if strings.TrimSpace(path) == "" {
+			return fmt.Errorf("cases[%d]: path is required and non-empty", i)
+		}
+	}
+	return nil
+}
+
+// Filter describes which cases to include in the run. Empty fields impose no
+// restriction. Tag filtering uses any-match semantics: a case passes if any of
+// its tags appears in the filter list.
+type Filter struct {
+	Tags []string // any-match against each case's tags
+	// Paths restricts the run to cases at (or under) these absolute file/dir
+	// paths. Empty = no path restriction. Backs the positional `oats <path>…`
+	// scoping, which selects which cases run without changing where the config
+	// is loaded from.
+	Paths []string
+}
+
+// Plan is a fixture-boot group: one fixture plus the cases that share it. The
+// fixture boots once and the plan's cases run serially against it; distinct
+// plans are independent and may run in parallel where fixture isolation allows.
+type Plan struct {
+	Name             string   // derived label for reporting/filtering output
+	Tags             []string // union of the member cases' tags (sorted)
+	Fixture          casefile.FixtureConfig
+	FixtureSourceDir string
+	Cases            []*casefile.Case
+}
+
+// PlanRun loads the configured cases, applies the filter, and groups the
+// survivors into plans by fixture identity. Plans are returned in the order
+// their fixtures first appear; cases are sorted by SourcePath for stable
+// ordering, so a plan's cases keep that order too.
+func (c *RootConfig) PlanRun(f Filter) ([]Plan, error) {
+	cases, err := c.loadCases()
+	if err != nil {
+		return nil, err
+	}
+	cases = keepCasesUnderPaths(cases, f.Paths)
+	cases = keepCasesWithTags(cases, f.Tags)
+	if len(cases) == 0 {
+		return nil, nil
+	}
+
+	// Group by fixture identity, preserving first-appearance order.
+	var order []string
+	groups := map[string][]*casefile.Case{}
+	fixtures := map[string]casefile.FixtureConfig{}
+	dirs := map[string]string{}
+	for _, tc := range cases {
+		fx, dir := c.fixtureFor(tc)
+		key := groupKey(fx, dir)
+		if _, ok := groups[key]; !ok {
+			order = append(order, key)
+			fixtures[key] = fx
+			dirs[key] = dir
+		}
+		groups[key] = append(groups[key], tc)
+	}
+
+	plans := make([]Plan, 0, len(order))
+	for _, key := range order {
+		gcs := groups[key]
+		plans = append(plans, Plan{
+			Name:             deriveGroupName(fixtures[key], gcs),
+			Tags:             unionTags(gcs),
+			Fixture:          fixtures[key],
+			FixtureSourceDir: dirs[key],
+			Cases:            gcs,
+		})
+	}
+	return plans, nil
+}
+
+// loadCases expands every glob in Cases (relative to SourceDir), dedupes
+// overlapping matches, loads each case, and returns them sorted by SourcePath.
+func (c *RootConfig) loadCases() ([]*casefile.Case, error) {
+	seen := make(map[string]struct{})
+	var cases []*casefile.Case
+	for _, pattern := range c.Cases {
+		abs := filepath.Join(c.SourceDir, pattern)
+		matches, err := filepath.Glob(abs)
+		if err != nil {
+			return nil, fmt.Errorf("glob %q: %w", pattern, err)
+		}
+		if len(matches) == 0 {
+			return nil, fmt.Errorf("glob %q matched zero files", pattern)
+		}
+		for _, m := range matches {
+			if _, dup := seen[m]; dup {
+				continue
+			}
+			seen[m] = struct{}{}
+			tc, loadErr := casefile.Load(m)
+			if loadErr != nil {
+				return nil, loadErr
+			}
+			cases = append(cases, tc)
+		}
+	}
+	sort.Slice(cases, func(i, j int) bool {
+		return cases[i].SourcePath < cases[j].SourcePath
+	})
+	return cases, nil
+}
+
+// fixtureFor returns the case's fixture (or the default lgtm compose when the
+// case declares none) and the directory its relative paths resolve against.
+func (c *RootConfig) fixtureFor(tc *casefile.Case) (casefile.FixtureConfig, string) {
+	if tc.Fixture == nil {
+		// No fixture: default to a compose fixture with the builtin lgtm
+		// template (an empty ComposeFixture resolves to template=lgtm). This
+		// boots just the lgtm stack, which is handy for inline-otlp cases.
+		// Temp compose files land next to the config.
+		return casefile.FixtureConfig{Compose: &casefile.ComposeFixture{}}, c.SourceDir
+	}
+	return *tc.Fixture, filepath.Dir(tc.SourcePath)
+}
+
+// groupKey identifies the fixture-boot group a case belongs to. Cases with
+// deep-equal fixtures share one boot; a fixture that resolves files relative to
+// its directory (compose file/files, k3d manifests) additionally keys on that
+// directory, since the same relative path means different files in different
+// directories. A path-less fixture (remote, or a template-only compose) keys on
+// the fixture alone, so identical copies in different directories share one boot.
+func groupKey(f casefile.FixtureConfig, dir string) string {
+	b, _ := json.Marshal(f)
+	key := string(b)
+	if f.UsesRelativePaths() {
+		key += "\x00" + dir
+	}
+	return key
+}
+
+// keepCasesUnderPaths returns the cases whose source file is one of paths or
+// lives under one of them (dir scope). paths must be absolute and cleaned.
+func keepCasesUnderPaths(cases []*casefile.Case, paths []string) []*casefile.Case {
+	if len(paths) == 0 {
+		return cases
+	}
+	var kept []*casefile.Case
+	for _, tc := range cases {
+		abs, err := filepath.Abs(tc.SourcePath)
+		if err != nil {
+			continue
+		}
+		for _, p := range paths {
+			if abs == p || strings.HasPrefix(abs, p+string(filepath.Separator)) {
+				kept = append(kept, tc)
+				break
+			}
+		}
+	}
+	return kept
+}
+
+// keepCasesWithTags returns the cases with at least one tag in tags (any-match).
+func keepCasesWithTags(cases []*casefile.Case, tags []string) []*casefile.Case {
+	if len(tags) == 0 {
+		return cases
+	}
+	var kept []*casefile.Case
+	for _, tc := range cases {
+		for _, want := range tags {
+			if slicesContains(tc.Tags, want) {
+				kept = append(kept, tc)
+				break
+			}
+		}
+	}
+	return kept
+}
+
+func slicesContains(haystack []string, want string) bool {
+	for _, h := range haystack {
+		if h == want {
+			return true
+		}
+	}
+	return false
+}
+
+func unionTags(cases []*casefile.Case) []string {
+	seen := make(map[string]struct{})
+	var tags []string
+	for _, tc := range cases {
+		for _, t := range tc.Tags {
+			if _, ok := seen[t]; ok {
+				continue
+			}
+			seen[t] = struct{}{}
+			tags = append(tags, t)
+		}
+	}
+	sort.Strings(tags)
+	return tags
+}
+
+// deriveGroupName produces a readable label for a plan. A single case uses its
+// name (or its directory); multiple cases use their common directory, falling
+// back to the fixture kind and count.
+func deriveGroupName(f casefile.FixtureConfig, cases []*casefile.Case) string {
+	if len(cases) == 1 {
+		if n := strings.TrimSpace(cases[0].Name); n != "" {
+			return n
+		}
+		if lbl := dirLabel(filepath.Dir(cases[0].SourcePath)); lbl != "" {
+			return lbl
+		}
+	}
+	if lbl := dirLabel(commonDir(cases)); lbl != "" {
+		return lbl
+	}
+	kind := f.Kind()
+	if kind == "" {
+		kind = "cases"
+	}
+	return fmt.Sprintf("%s (%d cases)", kind, len(cases))
+}
+
+// commonDir returns the longest directory prefix shared by every case's source
+// file, or "" if they share none.
+func commonDir(cases []*casefile.Case) string {
+	if len(cases) == 0 {
+		return ""
+	}
+	parts := strings.Split(filepath.Dir(cases[0].SourcePath), string(filepath.Separator))
+	for _, tc := range cases[1:] {
+		other := strings.Split(filepath.Dir(tc.SourcePath), string(filepath.Separator))
+		n := len(parts)
+		if len(other) < n {
+			n = len(other)
+		}
+		i := 0
+		for i < n && parts[i] == other[i] {
+			i++
+		}
+		parts = parts[:i]
+	}
+	return strings.Join(parts, string(filepath.Separator))
+}
+
+func dirLabel(dir string) string {
+	base := filepath.Base(dir)
+	if base == "oats" {
+		parent := filepath.Base(filepath.Dir(dir))
+		if parent != "." && parent != string(filepath.Separator) && parent != "" {
+			return parent
+		}
+	}
+	if base == "." || base == string(filepath.Separator) {
+		return ""
+	}
+	return base
+}
+
+// Summary renders one line per plan for `oats list`.
+func Summary(plans []Plan) string {
+	var out strings.Builder
+	for _, p := range plans {
+		names := make([]string, len(p.Cases))
+		for i, tc := range p.Cases {
+			names[i] = tc.Name
+		}
+		fmt.Fprintf(&out, "plan=%s fixture=%s tags=%v cases=%v\n", p.Name, p.Fixture.Kind(), p.Tags, names)
+	}
+	return out.String()
+}

--- a/discovery/discovery.go
+++ b/discovery/discovery.go
@@ -17,6 +17,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"slices"
 	"sort"
 	"strings"
 
@@ -244,22 +245,13 @@ func keepCasesWithTags(cases []*casefile.Case, tags []string) []*casefile.Case {
 	var kept []*casefile.Case
 	for _, tc := range cases {
 		for _, want := range tags {
-			if slicesContains(tc.Tags, want) {
+			if slices.Contains(tc.Tags, want) {
 				kept = append(kept, tc)
 				break
 			}
 		}
 	}
 	return kept
-}
-
-func slicesContains(haystack []string, want string) bool {
-	for _, h := range haystack {
-		if h == want {
-			return true
-		}
-	}
-	return false
 }
 
 func unionTags(cases []*casefile.Case) []string {

--- a/discovery/discovery_test.go
+++ b/discovery/discovery_test.go
@@ -1,0 +1,423 @@
+package discovery
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, rel, body string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+const validCaseYAML = `name: %s
+fixture:
+  compose:
+    template: lgtm
+seed:
+  type: app
+  compose: docker-compose.app.yml
+expected:
+  traces:
+    - traceql: '{}'
+      contains: ["x"]
+`
+
+// remoteCaseYAML builds a minimal case that points at a remote fixture. Optional
+// tags let the tag-filter test exercise case-level tag matching.
+func remoteCaseYAML(name, endpoint string, tags ...string) string {
+	body := "name: " + name + "\n"
+	if len(tags) > 0 {
+		body += "tags: [" + strings.Join(tags, ", ") + "]\n"
+	}
+	body += "fixture:\n  remote:\n    endpoint: " + endpoint + "\n"
+	body += `seed:
+  type: app
+expected:
+  traces:
+    - traceql: '{}'
+      absent: true
+`
+	return body
+}
+
+// composeFileCaseYAML builds a case with a dir-relative compose file fixture, so
+// its group key includes the case's directory.
+func composeFileCaseYAML(name string) string {
+	return "name: " + name + `
+fixture:
+  compose:
+    file: docker-compose.oats.yml
+seed:
+  type: app
+expected:
+  traces:
+    - traceql: '{}'
+      absent: true
+`
+}
+
+func TestLoad_ValidConfig(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+meta:
+  version: 3
+cases: ["cases/*.yaml"]
+`)
+	writeFile(t, dir, "cases/a.yaml", strings.Replace(validCaseYAML, "%s", "case-a", 1))
+	writeFile(t, dir, "cases/b.yaml", strings.Replace(validCaseYAML, "%s", "case-b", 1))
+
+	cfg, err := Load(filepath.Join(dir, "oats-config.yaml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Both cases declare the same path-less compose fixture, so they group into
+	// one plan.
+	plans, err := cfg.PlanRun(Filter{})
+	if err != nil {
+		t.Fatalf("PlanRun: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans: got %d, want 1", len(plans))
+	}
+	if len(plans[0].Cases) != 2 {
+		t.Errorf("cases: got %d, want 2", len(plans[0].Cases))
+	}
+	if plans[0].Cases[0].Name != "case-a" {
+		t.Errorf("sort order: got %q first", plans[0].Cases[0].Name)
+	}
+	if plans[0].Fixture.Kind() != "compose" {
+		t.Errorf("fixture resolved wrong: %+v", plans[0].Fixture)
+	}
+}
+
+func TestLoad_RejectsUnknownKey(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+meta:
+  version: 3
+typooo: boom
+cases: ["a.yaml"]
+`)
+	_, err := Load(filepath.Join(dir, "oats-config.yaml"))
+	if err == nil || !strings.Contains(err.Error(), "typooo") {
+		t.Errorf("expected unknown-key error, got %v", err)
+	}
+}
+
+func TestPlanRun_FilterByTag(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+meta:
+  version: 3
+cases: ["cases/*.yaml"]
+`)
+	writeFile(t, dir, "cases/a.yaml", remoteCaseYAML("a", "http://localhost:4318", "traces"))
+	writeFile(t, dir, "cases/b.yaml", remoteCaseYAML("b", "http://localhost:4318", "logs"))
+
+	cfg, err := Load(filepath.Join(dir, "oats-config.yaml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	// Tag filtering is case-level (any-match) and runs before grouping, so only
+	// the traces-tagged case survives.
+	plans, err := cfg.PlanRun(Filter{Tags: []string{"traces"}})
+	if err != nil {
+		t.Fatalf("PlanRun: %v", err)
+	}
+	if len(plans) != 1 || len(plans[0].Cases) != 1 || plans[0].Cases[0].Name != "a" {
+		t.Errorf("tag filter: %+v", planNames(plans))
+	}
+}
+
+func TestSummary(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+meta:
+  version: 3
+cases: ["cases/*.yaml"]
+`)
+	writeFile(t, dir, "cases/a.yaml", remoteCaseYAML("case-a", "http://localhost:4318", "traces"))
+
+	cfg, err := Load(filepath.Join(dir, "oats-config.yaml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	plans, err := cfg.PlanRun(Filter{})
+	if err != nil {
+		t.Fatalf("PlanRun: %v", err)
+	}
+
+	got := Summary(plans)
+	if !strings.Contains(got, "plan=case-a") {
+		t.Fatalf("Summary missing plan name: %q", got)
+	}
+	if !strings.Contains(got, "fixture=remote") {
+		t.Fatalf("Summary missing fixture kind: %q", got)
+	}
+	if !strings.Contains(got, "case-a") {
+		t.Fatalf("Summary missing case name: %q", got)
+	}
+}
+
+func TestPlanRun_FilterByPath(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+meta:
+  version: 3
+cases: ["a/*.yaml", "b/*.yaml"]
+`)
+	writeFile(t, dir, "a/x.yaml", strings.Replace(validCaseYAML, "%s", "ax", 1))
+	writeFile(t, dir, "b/y.yaml", strings.Replace(validCaseYAML, "%s", "by", 1))
+
+	cfg, err := Load(filepath.Join(dir, "oats-config.yaml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+
+	// Directory scope: only the case under a/ survives.
+	plans, err := cfg.PlanRun(Filter{Paths: []string{filepath.Join(dir, "a")}})
+	if err != nil {
+		t.Fatalf("PlanRun dir scope: %v", err)
+	}
+	if len(plans) != 1 || len(plans[0].Cases) != 1 || plans[0].Cases[0].Name != "ax" {
+		t.Fatalf("dir path filter: %+v", planNames(plans))
+	}
+
+	// Single-file scope: the exact case file.
+	plans, err = cfg.PlanRun(Filter{Paths: []string{filepath.Join(dir, "b", "y.yaml")}})
+	if err != nil {
+		t.Fatalf("PlanRun file scope: %v", err)
+	}
+	if len(plans) != 1 || len(plans[0].Cases) != 1 || plans[0].Cases[0].Name != "by" {
+		t.Fatalf("file path filter: %+v", planNames(plans))
+	}
+}
+
+func TestPlanRun_NoFixtureDefaultsToComposeLGTM(t *testing.T) {
+	// A case that declares no fixture defaults to a compose fixture booting the
+	// builtin lgtm stack, rooted at the config's source dir.
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+meta:
+  version: 3
+cases: ["cases/*.yaml"]
+`)
+	writeFile(t, dir, "cases/a.yaml", `name: inline smoke
+seed:
+  type: inline-otlp
+  logs:
+    - service: a
+      body: line
+expected:
+  logs:
+    - logql: '{service_name="a"}'
+      contains: line
+`)
+
+	cfg, err := Load(filepath.Join(dir, "oats-config.yaml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	plans, err := cfg.PlanRun(Filter{})
+	if err != nil {
+		t.Fatalf("PlanRun: %v", err)
+	}
+	if len(plans) != 1 {
+		t.Fatalf("plans: got %d, want 1", len(plans))
+	}
+	if plans[0].Fixture.Kind() != "compose" {
+		t.Fatalf("expected no-fixture case to default to compose, got %q (%+v)", plans[0].Fixture.Kind(), plans[0].Fixture)
+	}
+	if got := plans[0].Fixture.Compose.EffectiveTemplate(); got != "lgtm" {
+		t.Fatalf("expected default compose template lgtm, got %q", got)
+	}
+	if plans[0].FixtureSourceDir != dir {
+		t.Fatalf("expected fixture source dir %q, got %q", dir, plans[0].FixtureSourceDir)
+	}
+}
+
+// TestPlanRun_GroupsPathlessFixtureAcrossDirs verifies that cases with identical
+// path-less fixtures (here remote) in different directories land in one plan:
+// grouping keys on the fixture alone, since a remote fixture references no
+// directory-relative paths.
+func TestPlanRun_GroupsPathlessFixtureAcrossDirs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+meta:
+  version: 3
+cases: ["*/oats-case.yaml"]
+`)
+	writeFile(t, dir, "a/oats-case.yaml", remoteCaseYAML("a", "http://localhost:4318"))
+	writeFile(t, dir, "b/oats-case.yaml", remoteCaseYAML("b", "http://localhost:4318"))
+
+	cfg, err := Load(filepath.Join(dir, "oats-config.yaml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	plans, err := cfg.PlanRun(Filter{})
+	if err != nil {
+		t.Fatalf("PlanRun: %v", err)
+	}
+	if len(plans) != 1 || len(plans[0].Cases) != 2 {
+		t.Fatalf("expected one plan with two cases, got %+v", planNames(plans))
+	}
+	if plans[0].Fixture.Kind() != "remote" {
+		t.Fatalf("expected remote fixture, got %q", plans[0].Fixture.Kind())
+	}
+}
+
+// TestPlanRun_SeparatesDirRelativeFixtureAcrossDirs verifies that cases with the
+// same dir-relative fixture (compose file) in different directories land in
+// separate plans: the relative file means different files per directory, so the
+// group key includes the directory.
+func TestPlanRun_SeparatesDirRelativeFixtureAcrossDirs(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+meta:
+  version: 3
+cases: ["*/oats-case.yaml"]
+`)
+	writeFile(t, dir, "a/oats-case.yaml", composeFileCaseYAML("a"))
+	writeFile(t, dir, "b/oats-case.yaml", composeFileCaseYAML("b"))
+
+	cfg, err := Load(filepath.Join(dir, "oats-config.yaml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	plans, err := cfg.PlanRun(Filter{})
+	if err != nil {
+		t.Fatalf("PlanRun: %v", err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("expected two plans (one per dir), got %+v", planNames(plans))
+	}
+	for _, p := range plans {
+		if len(p.Cases) != 1 || p.Fixture.Kind() != "compose" {
+			t.Fatalf("unexpected plan: %+v", p)
+		}
+	}
+}
+
+func TestPlanRun_EmptyGlobIsAnError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+meta:
+  version: 3
+cases: ["nope/*.yaml"]
+`)
+	cfg, err := Load(filepath.Join(dir, "oats-config.yaml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	_, err = cfg.PlanRun(Filter{})
+	if err == nil || !strings.Contains(err.Error(), "matched zero files") {
+		t.Errorf("expected zero-match error, got %v", err)
+	}
+}
+
+// skipIfAbsent skips a test that validates a shipped example config when
+// examples/ is not present in the tree. In the split PR stack examples/ lands
+// in a later PR; once merged (and on main) these tests run for real.
+func skipIfAbsent(t *testing.T, path string) {
+	t.Helper()
+	if _, err := os.Stat(path); err != nil {
+		t.Skipf("%s not present in this build (ships with examples/)", path)
+	}
+}
+
+func TestExampleV2SmokeConfigLoads(t *testing.T) {
+	path := filepath.Join("..", "examples", "smoke", "oats-config.yaml")
+	skipIfAbsent(t, path)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load example config: %v", err)
+	}
+	plans, err := cfg.PlanRun(Filter{})
+	if err != nil {
+		t.Fatalf("PlanRun example config: %v", err)
+	}
+	// All four smoke cases share one remote fixture, so they form a single plan.
+	if len(plans) != 1 || len(plans[0].Cases) != 4 {
+		t.Fatalf("expected one plan/four cases, got %+v", plans)
+	}
+	got := []string{plans[0].Cases[0].Name, plans[0].Cases[1].Name, plans[0].Cases[2].Name, plans[0].Cases[3].Name}
+	want := []string{"custom check smoke", "inline seed smoke", "profile smoke", "rolldice smoke"}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("unexpected case order: got %v want %v", got, want)
+		}
+	}
+}
+
+func TestExampleV2FixturesConfigLoads(t *testing.T) {
+	path := filepath.Join("..", "examples", "fixtures", "oats-config.yaml")
+	skipIfAbsent(t, path)
+	cfg, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load fixture example config: %v", err)
+	}
+	plans, err := cfg.PlanRun(Filter{})
+	if err != nil {
+		t.Fatalf("PlanRun fixture example config: %v", err)
+	}
+	// The compose case and k3d case declare different fixtures, so they form two
+	// independent plans, ordered by first fixture appearance (compose case sorts
+	// before the k3d case by source path).
+	if len(plans) != 2 {
+		t.Fatalf("expected two plans, got %+v", plans)
+	}
+	if plans[0].Fixture.Kind() != "compose" || len(plans[0].Cases) != 1 {
+		t.Fatalf("unexpected first plan: %+v", plans[0])
+	}
+	if plans[1].Fixture.Kind() != "k3d" || len(plans[1].Cases) != 1 {
+		t.Fatalf("unexpected second plan: %+v", plans[1])
+	}
+	if plans[1].Cases[0].Name != "k3d fixture app smoke" {
+		t.Fatalf("unexpected k3d case name: %q", plans[1].Cases[0].Name)
+	}
+}
+
+func planNames(p []Plan) []string {
+	out := make([]string, len(p))
+	for i := range p {
+		out[i] = p[i].Name
+	}
+	return out
+}
+
+func TestLoadTopLevelCases(t *testing.T) {
+	// Two cases with different fixtures (distinct remote endpoints) become two
+	// separate plans.
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+cases: ["cases/a.yaml", "cases/b.yaml"]
+meta:
+  version: 3
+`)
+	writeFile(t, dir, "cases/a.yaml", remoteCaseYAML("a", "http://localhost:4318"))
+	writeFile(t, dir, "cases/b.yaml", remoteCaseYAML("b", "http://localhost:4319"))
+	cfg, err := Load(filepath.Join(dir, "oats-config.yaml"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	plans, err := cfg.PlanRun(Filter{})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(plans) != 2 {
+		t.Fatalf("expected 2 plans, got %d", len(plans))
+	}
+	if plans[0].Name != "a" || plans[1].Name != "b" {
+		t.Fatalf("unexpected plan names: %q, %q", plans[0].Name, plans[1].Name)
+	}
+}


### PR DESCRIPTION
Part **3/8** of splitting #334. Stacked on #369.

## What
`discovery`: load cases, apply tag/path filters, and group them into fixture-boot groups **derived** from fixture identity (same fixture → one boot; different fixtures → parallel-eligible). Replaces the old explicit `suites` concept.

## Depends on
#369
