### PR TITLE
feat(fixture): compose + k3d fixture lifecycle

### DIFF
--- a/fixture/compose.go
+++ b/fixture/compose.go
@@ -1,0 +1,348 @@
+package fixture
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/grafana/oats/casefile"
+	"github.com/grafana/oats/discovery"
+	"github.com/grafana/oats/testhelpers"
+)
+
+const (
+	composeCLIBinary   = "docker"
+	lgtmComposeService = "lgtm"
+)
+
+func portString(port int) string {
+	return strconv.Itoa(port)
+}
+
+func startCompose(plan discovery.Plan) (Handle, Runtime, error) {
+	compose := plan.Fixture.Compose
+	composeFiles, cleanup, err := resolveComposeFiles(plan.FixtureSourceDir, compose)
+	if err != nil {
+		return nil, Runtime{}, err
+	}
+	project := composeProjectName(plan)
+	suiteEnv := append([]string(nil), compose.Env...)
+	suiteEnv = append(suiteEnv, "COMPOSE_PROJECT_NAME="+project)
+	suite, err := newComposeSuite(composeFiles, suiteEnv)
+	if err != nil {
+		if cleanup != nil {
+			_ = cleanup()
+		}
+		return nil, Runtime{}, err
+	}
+	if err := startSuiteFixture(suite); err != nil {
+		if cleanup != nil {
+			_ = cleanup()
+		}
+		return nil, Runtime{}, err
+	}
+	// fail tears the started suite (and any file cleanup) down before returning.
+	fail := func(err error) (Handle, Runtime, error) {
+		_ = suite.Close()
+		if cleanup != nil {
+			_ = cleanup()
+		}
+		return nil, Runtime{}, err
+	}
+	grafanaPort, err := lookupComposePort(composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.GrafanaHTTPPort))
+	if err != nil {
+		return fail(err)
+	}
+	otlpPort, err := lookupComposePort(composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.OTLPHTTPPort))
+	if err != nil {
+		return fail(err)
+	}
+	pyroscopePort, err := lookupComposePort(composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.PyroscopeHTTPPort))
+	if err != nil {
+		return fail(err)
+	}
+	rt := Runtime{
+		GrafanaURL:     "http://" + testhelpers.LocalhostIPv4 + ":" + grafanaPort,
+		OTLPHTTP:       "http://" + testhelpers.LocalhostIPv4 + ":" + otlpPort,
+		PyroscopeURL:   "http://" + testhelpers.LocalhostIPv4 + ":" + pyroscopePort,
+		ComposeFiles:   composeFiles,
+		ComposeProject: project,
+	}
+	// When the fixture manages the app (app_service + app_port), resolve the host
+	// port docker published for it. This lets the app bind an ephemeral host port
+	// (127.0.0.1::<port>) instead of a fixed one, which is what makes app-seed
+	// suites parallel-safe.
+	if plan.Fixture.HasManagedApp() {
+		appPort, portErr := lookupComposePort(composeFiles, suiteEnv, compose.AppService, strconv.Itoa(compose.AppPort))
+		if portErr != nil {
+			return fail(fmt.Errorf("resolve app host port for service %q: %w", compose.AppService, portErr))
+		}
+		p, convErr := strconv.Atoi(appPort)
+		if convErr != nil {
+			return fail(fmt.Errorf("invalid app host port %q for service %q: %w", appPort, compose.AppService, convErr))
+		}
+		rt.AppHostPort = p
+	}
+	cfg, cfgErr := writeLocalGCXConfig(rt.GrafanaURL)
+	if cfgErr != nil {
+		return fail(fmt.Errorf("write local gcx config: %w", cfgErr))
+	}
+	rt.GCXConfig = cfg
+	cleanup = chainCleanup(func() error { return removeIfExists(cfg) }, cleanup)
+	rt.CustomCheckEnv = composeCheckEnv(plan, rt)
+	rt.ParallelSafe, rt.ParallelDisabled = SupportsParallel(plan)
+	return composeFixture{suite: suite, cleanup: cleanup}, rt, nil
+}
+
+func resolveComposeFiles(sourceDir string, compose *casefile.ComposeFixture) ([]string, func() error, error) {
+	var files []string
+	var cleanup func() error
+	template := compose.EffectiveTemplate()
+	switch template {
+	case "lgtm":
+		f, err := writeBuiltinLGTMCompose(sourceDir)
+		if err != nil {
+			return nil, nil, err
+		}
+		files = append(files, f)
+		cleanup = func() error { return os.Remove(f) }
+	case "none":
+		// Bring-your-own-stack: no builtin is booted, only the user's file/files.
+	default:
+		return nil, nil, fmt.Errorf("unsupported compose template %q", compose.Template)
+	}
+	switch {
+	case compose.File != "":
+		files = append(files, filepath.Join(sourceDir, compose.File))
+	case len(compose.Files) > 0:
+		for _, file := range compose.Files {
+			files = append(files, filepath.Join(sourceDir, file))
+		}
+	case template == "none":
+		return nil, nil, fmt.Errorf("compose template=none requires file or files")
+	}
+	return files, cleanup, nil
+}
+
+func writeBuiltinLGTMCompose(sourceDir string) (string, error) {
+	if err := os.MkdirAll(sourceDir, 0o755); err != nil {
+		return "", err
+	}
+	f, err := os.CreateTemp(sourceDir, ".oats.lgtm.*.compose.yml")
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+	body := `services:
+  lgtm:
+    image: ${LGTM_IMAGE:-docker.io/grafana/otel-lgtm:latest}
+    ports:
+      - "` + testhelpers.LocalhostIPv4 + `::` + portString(testhelpers.GrafanaHTTPPort) + `"
+      - "` + testhelpers.LocalhostIPv4 + `::` + portString(testhelpers.OTLPGRPCPort) + `"
+      - "` + testhelpers.LocalhostIPv4 + `::` + portString(testhelpers.OTLPHTTPPort) + `"
+      - "` + testhelpers.LocalhostIPv4 + `::` + portString(testhelpers.TempoHTTPPort) + `"
+      - "` + testhelpers.LocalhostIPv4 + `::` + portString(testhelpers.PyroscopeHTTPPort) + `"
+      - "` + testhelpers.LocalhostIPv4 + `::` + portString(testhelpers.PrometheusHTTPPort) + `"
+`
+	if _, err := f.WriteString(body); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
+}
+
+func composeCheckEnv(plan discovery.Plan, rt Runtime) []string {
+	files := rt.ComposeFiles
+	if len(files) == 0 {
+		return []string{"OATS_FIXTURE_TYPE=compose"}
+	}
+	return []string{
+		"OATS_FIXTURE_TYPE=compose",
+		"COMPOSE_PROJECT_NAME=" + rt.ComposeProject,
+		"COMPOSE_FILE=" + strings.Join(files, string(os.PathListSeparator)),
+		"OATS_COMPOSE_FILE_ARGS=" + composeFileArgs(files),
+		"OATS_GRAFANA_URL=" + rt.GrafanaURL,
+		"OATS_OTLP_HTTP=" + rt.OTLPHTTP,
+		"OATS_PYROSCOPE_URL=" + rt.PyroscopeURL,
+	}
+}
+
+func composeFileArgs(files []string) string {
+	var parts []string
+	for _, f := range files {
+		parts = append(parts, "-f", shellQuote(f))
+	}
+	return strings.Join(parts, " ")
+}
+
+func shellQuote(s string) string {
+	return "'" + strings.ReplaceAll(s, "'", `'\''`) + "'"
+}
+
+func composeProjectName(plan discovery.Plan) string {
+	name := strings.ToLower(plan.Name)
+	if name == "" {
+		name = "oats"
+	}
+	var b strings.Builder
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9':
+			b.WriteRune(r)
+		default:
+			b.WriteByte('-')
+		}
+	}
+	slug := strings.Trim(b.String(), "-")
+	if slug == "" {
+		slug = "oats"
+	}
+	if len(slug) > 32 {
+		slug = slug[:32]
+	}
+	return fmt.Sprintf("oats-%s-%d", slug, time.Now().UnixNano())
+}
+
+func extraComposeFiles(plan discovery.Plan) []string {
+	compose := plan.Fixture.Compose
+	switch {
+	case compose.File != "":
+		return []string{filepath.Join(plan.FixtureSourceDir, compose.File)}
+	case len(compose.Files) > 0:
+		files := make([]string, 0, len(compose.Files))
+		for _, file := range compose.Files {
+			files = append(files, filepath.Join(plan.FixtureSourceDir, file))
+		}
+		return files
+	default:
+		return nil
+	}
+}
+
+func composeFilePublishesFixedHostPorts(path string) (bool, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return false, err
+	}
+	lines := strings.Split(string(data), "\n")
+	inPorts := false
+	portsIndent := 0
+	for _, line := range lines {
+		trimmed := strings.TrimSpace(line)
+		if trimmed == "" || strings.HasPrefix(trimmed, "#") {
+			continue
+		}
+		indent := len(line) - len(strings.TrimLeft(line, " "))
+		if inPorts && indent <= portsIndent {
+			inPorts = false
+		}
+		if strings.HasPrefix(trimmed, "ports:") {
+			inPorts = true
+			portsIndent = indent
+			continue
+		}
+		if !inPorts {
+			continue
+		}
+		if strings.Contains(trimmed, "published:") {
+			value := strings.TrimSpace(strings.TrimPrefix(trimmed, "published:"))
+			if value != "" && value != "0" {
+				return true, nil
+			}
+			continue
+		}
+		if !strings.HasPrefix(trimmed, "-") {
+			continue
+		}
+		value := strings.Trim(strings.TrimSpace(strings.TrimPrefix(trimmed, "-")), `"'`)
+		if value == "" {
+			continue
+		}
+		if fixedShortPortMapping(value) {
+			return true, nil
+		}
+	}
+	return false, nil
+}
+
+func fixedShortPortMapping(value string) bool {
+	if !strings.Contains(value, ":") {
+		return false
+	}
+	parts := strings.Split(value, ":")
+	if len(parts) < 2 {
+		return false
+	}
+	hostPart := strings.Trim(parts[len(parts)-2], "[]")
+	if _, err := strconv.Atoi(hostPart); err == nil && hostPart != "0" {
+		return true
+	}
+	return false
+}
+
+func readComposeGrafanaToken(plan discovery.Plan) (string, error) {
+	compose := plan.Fixture.Compose
+	files, _, err := resolveComposeFiles(plan.FixtureSourceDir, compose)
+	if err != nil {
+		return "", err
+	}
+	args := []string{"compose"}
+	for _, f := range files {
+		args = append(args, "-f", f)
+	}
+	args = append(args, "exec", "-T", lgtmComposeService, "sh", "-c", "cat /tmp/grafana-sa-token 2>/dev/null || true")
+	cmd := exec.Command(composeCLIBinary, args...)
+	cmd.Env = append(cmd.Environ(), compose.Env...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}
+
+func dockerComposePort(files []string, env []string, service, containerPort string) (string, error) {
+	args := []string{"compose"}
+	for _, f := range files {
+		args = append(args, "-f", f)
+	}
+	args = append(args, "port", service, containerPort)
+	cmd := exec.Command(composeCLIBinary, args...)
+	cmd.Env = append(cmd.Environ(), env...)
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	host, port, err := splitDockerHostPort(strings.TrimSpace(string(out)))
+	if err != nil {
+		return "", err
+	}
+	if host == "" || port == "" {
+		return "", fmt.Errorf("invalid docker compose port output %q", strings.TrimSpace(string(out)))
+	}
+	return port, nil
+}
+
+func splitDockerHostPort(addr string) (string, string, error) {
+	addr = strings.TrimSpace(addr)
+	if strings.HasPrefix(addr, "[") {
+		end := strings.Index(addr, "]")
+		if end < 0 || end+2 > len(addr) || addr[end+1] != ':' {
+			return "", "", fmt.Errorf("invalid address %q", addr)
+		}
+		return addr[1:end], addr[end+2:], nil
+	}
+	idx := strings.LastIndex(addr, ":")
+	if idx < 0 {
+		return "", "", fmt.Errorf("invalid address %q", addr)
+	}
+	return addr[:idx], addr[idx+1:], nil
+}

--- a/fixture/fixture.go
+++ b/fixture/fixture.go
@@ -1,0 +1,293 @@
+// Package fixture owns the lifecycle of the observability backends a suite
+// runs against: booting a docker-compose or k3d stack, waiting for it to be
+// ready, exposing the resolved endpoints as a Runtime, and tearing it down.
+// The CLI orchestrates suites and reporting; this package abstracts "stand up
+// the stack the cases need" behind a small, pluggable surface.
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"net"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	"github.com/grafana/oats/discovery"
+	"github.com/grafana/oats/testhelpers/compose"
+	"github.com/grafana/oats/testhelpers/kubernetes"
+	"github.com/grafana/oats/testhelpers/remote"
+)
+
+// Seams overridable in tests.
+var (
+	newComposeSuite = func(files []string, env []string) (Handle, error) {
+		return compose.SuiteFiles(files, env)
+	}
+	newKubernetesEndpoint = func(plan discovery.Plan, ports remote.PortsConfig) *remote.Endpoint {
+		sourceDir := plan.FixtureSourceDir
+		if sourceDir == "" {
+			sourceDir = "."
+		}
+		k3d := plan.Fixture.K3D
+		model := &kubernetes.Kubernetes{
+			Dir:              k3d.K8sDir,
+			AppService:       k3d.AppService,
+			AppDockerFile:    k3d.AppDockerFile,
+			AppDockerContext: k3d.AppDockerContext,
+			AppDockerTag:     k3d.AppDockerTag,
+			AppDockerPort:    k3d.AppPort,
+			ImportImages:     k3d.ImportImages,
+		}
+		return kubernetes.NewEndpoint("localhost", model, ports, plan.Name, sourceDir)
+	}
+	waitForGrafanaToken = waitForGrafanaTokenImpl
+	lookupComposePort   = dockerComposePort
+)
+
+// Runtime carries the resolved coordinates of a booted fixture back to the
+// caller: where the backends live, the gcx config to talk to them, the compose
+// project (for teardown/labels), and whether the fixture is parallel-safe.
+type Runtime struct {
+	GrafanaURL       string
+	OTLPHTTP         string
+	PyroscopeURL     string
+	AppHostPort      int
+	CustomCheckEnv   []string
+	ComposeFiles     []string
+	ComposeProject   string
+	GCXConfig        string
+	ParallelSafe     bool
+	ParallelDisabled string
+}
+
+// Handle is a booted fixture that can be torn down.
+type Handle interface {
+	Close() error
+}
+
+type startableHandle interface {
+	Handle
+	Up() error
+}
+
+// Start boots the fixture declared by the plan and returns a Handle for
+// teardown plus the resolved Runtime. Remote/empty fixtures need no boot and
+// return a nil Handle.
+func Start(ctx context.Context, plan discovery.Plan) (Handle, Runtime, error) {
+	switch plan.Fixture.Kind() {
+	case "", "remote":
+		return nil, Runtime{ParallelSafe: true}, nil
+	case "compose":
+		return startCompose(plan)
+	case "k3d":
+		return startK3D(ctx, plan)
+	default:
+		return nil, Runtime{}, fmt.Errorf("fixture kind %q is not supported in oats", plan.Fixture.Kind())
+	}
+}
+
+// WaitForReady blocks until the fixture's Grafana and OTLP endpoints answer, or
+// the per-endpoint timeout elapses. Remote/empty fixtures are assumed ready.
+func WaitForReady(plan discovery.Plan, rt Runtime) error {
+	switch plan.Fixture.Kind() {
+	case "compose", "k3d":
+		if err := waitForHTTP(rt.GrafanaURL+"/api/health", 2*time.Minute); err != nil {
+			return fmt.Errorf("wait for grafana: %w", err)
+		}
+		if err := waitForHTTP(rt.OTLPHTTP, 2*time.Minute); err != nil {
+			return fmt.Errorf("wait for otlp-http: %w", err)
+		}
+	}
+	return nil
+}
+
+// SupportsParallel reports whether a suite on this fixture can run alongside
+// other suites, and if not, a human-readable reason.
+func SupportsParallel(plan discovery.Plan) (bool, string) {
+	switch plan.Fixture.Kind() {
+	case "", "remote":
+		return true, ""
+	case "compose":
+		if plan.Fixture.Compose.EffectiveTemplate() != "lgtm" {
+			return false, "compose fixtures are only parallel-safe when OATS owns the LGTM ports via template=lgtm"
+		}
+		for _, c := range plan.Cases {
+			// App seeds are parallel-safe only when OATS can give the app an
+			// ephemeral host port instead of a shared fixed one — which requires
+			// fixture.app_service (+ app_port) so the published port can be
+			// discovered. Without it the app falls back to the fixed --app-port
+			// and parallel suites would collide.
+			if c.Seed.EffectiveType() == "app" && !plan.Fixture.HasManagedApp() {
+				return false, "compose app-seed suites need fixture.app_service and app_port so OATS can publish an ephemeral app port; otherwise they share a fixed app port"
+			}
+		}
+		for _, file := range extraComposeFiles(plan) {
+			if fixed, err := composeFilePublishesFixedHostPorts(file); err != nil {
+				return false, fmt.Sprintf("compose port inspection failed for %s: %v", file, err)
+			} else if fixed {
+				return false, fmt.Sprintf("compose file %s publishes fixed host ports", filepath.Base(file))
+			}
+		}
+		return true, ""
+	case "k3d":
+		return false, "k3d fixtures currently use shared localhost port-forwards"
+	default:
+		return false, "fixture type is not parallel-safe"
+	}
+}
+
+func startSuiteFixture(fix Handle) error {
+	startable, ok := fix.(startableHandle)
+	if !ok {
+		return fmt.Errorf("fixture does not support startup")
+	}
+	return startable.Up()
+}
+
+type endpointFixture struct {
+	ep      *remote.Endpoint
+	cleanup func() error
+}
+
+func (e endpointFixture) Close() error {
+	err := e.ep.Stop(context.Background())
+	if e.cleanup != nil {
+		if cleanupErr := e.cleanup(); cleanupErr != nil && err == nil {
+			err = cleanupErr
+		}
+	}
+	return err
+}
+
+type composeFixture struct {
+	suite   Handle
+	cleanup func() error
+}
+
+func (c composeFixture) Close() error {
+	err := c.suite.Close()
+	if c.cleanup != nil {
+		if cleanupErr := c.cleanup(); cleanupErr != nil && err == nil {
+			err = cleanupErr
+		}
+	}
+	return err
+}
+
+// removeIfExists deletes path, ignoring a not-exist error so cleanup is
+// idempotent.
+func removeIfExists(path string) error {
+	if err := os.Remove(path); err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	return nil
+}
+
+// chainCleanup returns a cleanup that runs first then second, returning the
+// first non-nil error. Either argument may be nil.
+func chainCleanup(first, second func() error) func() error {
+	return func() error {
+		var err error
+		if first != nil {
+			err = first()
+		}
+		if second != nil {
+			if e := second(); e != nil && err == nil {
+				err = e
+			}
+		}
+		return err
+	}
+}
+
+func writeLocalGCXConfig(grafanaURL string) (string, error) {
+	cfg := fmt.Sprintf(`current-context: local
+contexts:
+  local:
+    grafana:
+      server: %s
+      user: admin
+      password: admin
+      org-id: 1
+      auth-method: basic
+    datasources:
+      prometheus: prometheus
+      loki: loki
+      tempo: tempo
+      pyroscope: pyroscope
+`, grafanaURL)
+	f, err := os.CreateTemp("", "oats-gcx-*.yaml")
+	if err != nil {
+		return "", err
+	}
+	path := f.Name()
+	if _, err := f.WriteString(cfg); err != nil {
+		_ = f.Close()
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := f.Close(); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	if err := os.Chmod(path, 0o600); err != nil {
+		_ = os.Remove(path)
+		return "", err
+	}
+	return path, nil
+}
+
+func waitForGrafanaTokenImpl(plan discovery.Plan) (string, error) {
+	deadline := time.Now().Add(3 * time.Minute)
+	for time.Now().Before(deadline) {
+		var token string
+		var err error
+		switch plan.Fixture.Kind() {
+		case "compose":
+			token, err = readComposeGrafanaToken(plan)
+		case "k3d":
+			token, err = readK3DGrafanaToken()
+		default:
+			return "", nil
+		}
+		if err == nil && strings.TrimSpace(token) != "" {
+			return strings.TrimSpace(token), nil
+		}
+		time.Sleep(time.Second)
+	}
+	return "", fmt.Errorf("timed out waiting for Grafana service-account token")
+}
+
+func findFreePort() (int, error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return 0, err
+	}
+	defer func() { _ = ln.Close() }()
+	addr, ok := ln.Addr().(*net.TCPAddr)
+	if !ok {
+		return 0, fmt.Errorf("unexpected listener address %T", ln.Addr())
+	}
+	return addr.Port, nil
+}
+
+func waitForHTTP(url string, timeout time.Duration) error {
+	// Bound each probe so a target that accepts TCP but never responds can't
+	// block a single GET past the overall deadline.
+	client := &http.Client{Timeout: 10 * time.Second}
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		resp, err := client.Get(url) //nolint:gosec
+		if err == nil {
+			_ = resp.Body.Close()
+			if resp.StatusCode >= 200 && resp.StatusCode < 500 {
+				return nil
+			}
+		}
+		time.Sleep(2 * time.Second)
+	}
+	return fmt.Errorf("timed out waiting for %s", url)
+}

--- a/fixture/fixture_test.go
+++ b/fixture/fixture_test.go
@@ -1,0 +1,440 @@
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/grafana/oats/casefile"
+	"github.com/grafana/oats/discovery"
+	"github.com/grafana/oats/runner"
+	"github.com/grafana/oats/testhelpers"
+	"github.com/grafana/oats/testhelpers/remote"
+)
+
+func isBuiltinLGTMFile(path string) bool {
+	return strings.Contains(filepath.Base(path), ".oats.lgtm.") && strings.HasSuffix(path, ".compose.yml")
+}
+
+func TestResolveComposeFiles(t *testing.T) {
+	dir := t.TempDir()
+
+	// template=none with a single file: only the user's file, no builtin, no
+	// cleanup.
+	got, cleanup, err := resolveComposeFiles(dir, &casefile.ComposeFixture{Template: "none", File: "stack/compose.yml"})
+	if err != nil {
+		t.Fatalf("resolveComposeFiles template=none file: %v", err)
+	}
+	if cleanup != nil {
+		t.Fatalf("unexpected cleanup for template=none file fixture")
+	}
+	if want := []string{filepath.Join(dir, "stack", "compose.yml")}; len(got) != 1 || got[0] != want[0] {
+		t.Fatalf("got %q want %q", got, want)
+	}
+
+	// template=none with files: only the user's files, no builtin.
+	got, cleanup, err = resolveComposeFiles(dir, &casefile.ComposeFixture{Template: "none", Files: []string{"a.yml", "b.yml"}})
+	if err != nil {
+		t.Fatalf("resolveComposeFiles template=none files: %v", err)
+	}
+	if cleanup != nil {
+		t.Fatalf("unexpected cleanup for template=none files fixture")
+	}
+	if len(got) != 2 || got[0] != filepath.Join(dir, "a.yml") || got[1] != filepath.Join(dir, "b.yml") {
+		t.Fatalf("unexpected files resolution: %v", got)
+	}
+
+	// No template + a user file: the builtin lgtm compose is merged in ahead of
+	// the user's file (default template=lgtm), with cleanup for the temp file.
+	got, cleanup, err = resolveComposeFiles(dir, &casefile.ComposeFixture{File: "stack/compose.yml"})
+	if err != nil {
+		t.Fatalf("resolveComposeFiles default template + file: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatalf("expected cleanup for default (lgtm) fixture")
+	}
+	if len(got) != 2 || !isBuiltinLGTMFile(got[0]) || got[1] != filepath.Join(dir, "stack", "compose.yml") {
+		_ = cleanup()
+		t.Fatalf("unexpected default-template resolution: %v", got)
+	}
+	_ = cleanup()
+
+	// Explicit template=lgtm with no file: just the builtin lgtm compose.
+	got, cleanup, err = resolveComposeFiles(dir, &casefile.ComposeFixture{Template: "lgtm"})
+	if err != nil {
+		t.Fatalf("resolveComposeFiles template=lgtm: %v", err)
+	}
+	if cleanup == nil {
+		t.Fatalf("expected cleanup for template=lgtm fixture")
+	}
+	defer func() { _ = cleanup() }()
+	if len(got) != 1 || !isBuiltinLGTMFile(got[0]) {
+		t.Fatalf("unexpected template=lgtm resolution: %v", got)
+	}
+}
+
+func TestStart_ComposeLifecycle(t *testing.T) {
+	oldFactory := newComposeSuite
+	oldLookup := lookupComposePort
+	defer func() { newComposeSuite = oldFactory }()
+	defer func() { lookupComposePort = oldLookup }()
+
+	var gotFiles, gotEnv []string
+	fake := &fakeHandle{}
+	newComposeSuite = func(files []string, env []string) (Handle, error) {
+		gotFiles = append([]string(nil), files...)
+		gotEnv = append([]string(nil), env...)
+		return fake, nil
+	}
+	lookupComposePort = func(files []string, env []string, service, containerPort string) (string, error) {
+		switch containerPort {
+		case "3000":
+			return "43000", nil
+		case "4318":
+			return "44318", nil
+		case "4040":
+			return "44040", nil
+		default:
+			return "", fmt.Errorf("unexpected port %s", containerPort)
+		}
+	}
+
+	sourceDir := t.TempDir()
+	fix, _, err := Start(context.Background(), discovery.Plan{
+		Name: "smoke",
+		Fixture: casefile.FixtureConfig{
+			Compose: &casefile.ComposeFixture{
+				// template=none keeps the resolved file list exactly a.yml/b.yml
+				// so this lifecycle test isn't perturbed by the builtin lgtm file.
+				Template: "none",
+				Files:    []string{"a.yml", "b.yml"},
+				Env:      []string{"FOO=bar"},
+			},
+		},
+		FixtureSourceDir: sourceDir,
+	})
+	if err != nil {
+		t.Fatalf("Start compose: %v", err)
+	}
+	if fake.upCalls != 1 {
+		t.Fatalf("expected Up once, got %d", fake.upCalls)
+	}
+	if want := []string{filepath.Join(sourceDir, "a.yml"), filepath.Join(sourceDir, "b.yml")}; !equalStrings(gotFiles, want) {
+		t.Fatalf("compose files: got %v want %v", gotFiles, want)
+	}
+	if len(gotEnv) != 2 || gotEnv[0] != "FOO=bar" || !strings.HasPrefix(gotEnv[1], "COMPOSE_PROJECT_NAME=oats-smoke-") {
+		t.Fatalf("compose env: got %v", gotEnv)
+	}
+	if err := fix.Close(); err != nil {
+		t.Fatalf("fixture close: %v", err)
+	}
+	if fake.closeCalls != 1 {
+		t.Fatalf("expected Close once, got %d", fake.closeCalls)
+	}
+}
+
+func TestStart_ComposeStartFailure(t *testing.T) {
+	oldFactory := newComposeSuite
+	defer func() { newComposeSuite = oldFactory }()
+
+	newComposeSuite = func(files []string, env []string) (Handle, error) {
+		return &fakeHandle{upErr: fmt.Errorf("boom")}, nil
+	}
+
+	_, _, err := Start(context.Background(), discovery.Plan{
+		Name:             "smoke",
+		Fixture:          casefile.FixtureConfig{Compose: &casefile.ComposeFixture{File: "compose.yml"}},
+		FixtureSourceDir: t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "boom") {
+		t.Fatalf("expected compose startup error, got %v", err)
+	}
+}
+
+func TestStart_K3DLifecycle(t *testing.T) {
+	oldFactory := newKubernetesEndpoint
+	defer func() { newKubernetesEndpoint = oldFactory }()
+
+	var capturedPlan discovery.Plan
+	var starts, stops int
+	var capturedPorts remote.PortsConfig
+	newKubernetesEndpoint = func(plan discovery.Plan, ports remote.PortsConfig) *remote.Endpoint {
+		capturedPlan = plan
+		capturedPorts = ports
+		return remote.NewEndpoint("localhost", remote.PortsConfig{}, func(ctx context.Context) error {
+			starts++
+			return nil
+		}, func(ctx context.Context) error {
+			stops++
+			return nil
+		}, nil)
+	}
+
+	sourceDir := t.TempDir()
+	fix, rt, err := Start(context.Background(), discovery.Plan{
+		Name: "cluster-smoke",
+		Fixture: casefile.FixtureConfig{
+			K3D: &casefile.K3DFixture{
+				K8sDir:           "k8s",
+				AppService:       "dice",
+				AppDockerFile:    "Dockerfile",
+				AppDockerContext: ".",
+				AppDockerTag:     "dice:test",
+				AppPort:          18080,
+				ImportImages:     []string{"busybox:latest"},
+			},
+		},
+		FixtureSourceDir: sourceDir,
+	})
+	if err != nil {
+		t.Fatalf("Start k3d: %v", err)
+	}
+	if rt.AppHostPort != 18080 {
+		t.Fatalf("expected Runtime.AppHostPort=18080 from fixture config, got %d", rt.AppHostPort)
+	}
+	if starts != 1 {
+		t.Fatalf("expected one endpoint start, got %d", starts)
+	}
+	if capturedPlan.FixtureSourceDir != sourceDir || capturedPlan.Name != "cluster-smoke" || capturedPlan.Fixture.K3D.AppPort != 18080 {
+		t.Fatalf("unexpected endpoint factory args: plan=%+v", capturedPlan)
+	}
+	if capturedPorts.GrafanaHTTPPort == 0 || capturedPorts.OTLPHTTPPort == 0 || capturedPorts.LokiHttpPort == 0 || capturedPorts.PrometheusHTTPPort == 0 || capturedPorts.TempoHTTPPort == 0 || capturedPorts.PyroscopeHttpPort == 0 {
+		t.Fatalf("expected allocated k3d ports, got %+v", capturedPorts)
+	}
+	if err := fix.Close(); err != nil {
+		t.Fatalf("fixture close: %v", err)
+	}
+	if stops != 1 {
+		t.Fatalf("expected one endpoint stop, got %d", stops)
+	}
+}
+
+func TestStart_K3DStartFailure(t *testing.T) {
+	oldFactory := newKubernetesEndpoint
+	defer func() { newKubernetesEndpoint = oldFactory }()
+
+	newKubernetesEndpoint = func(plan discovery.Plan, ports remote.PortsConfig) *remote.Endpoint {
+		return remote.NewEndpoint("localhost", remote.PortsConfig{}, func(ctx context.Context) error {
+			return fmt.Errorf("cluster boom")
+		}, func(ctx context.Context) error {
+			return nil
+		}, nil)
+	}
+
+	_, _, err := Start(context.Background(), discovery.Plan{
+		Name: "cluster-smoke",
+		Fixture: casefile.FixtureConfig{
+			K3D: &casefile.K3DFixture{
+				K8sDir:           "k8s",
+				AppService:       "dice",
+				AppDockerFile:    "Dockerfile",
+				AppDockerContext: ".",
+				AppDockerTag:     "dice:test",
+				AppPort:          18080,
+			},
+		},
+		FixtureSourceDir: t.TempDir(),
+	})
+	if err == nil || !strings.Contains(err.Error(), "cluster boom") {
+		t.Fatalf("expected k3d startup error, got %v", err)
+	}
+}
+
+func TestK3DCheckEnv_UsesConfiguredPorts(t *testing.T) {
+	got := k3dCheckEnv(runner.Endpoint{AppHost: testhelpers.LocalhostIPv4, AppPort: 18080}, remote.PortsConfig{
+		GrafanaHTTPPort:   13000,
+		OTLPHTTPPort:      14318,
+		PyroscopeHttpPort: 14040,
+	})
+	for _, want := range []string{
+		"OATS_APP_URL=http://127.0.0.1:18080",
+		"OATS_GRAFANA_URL=http://127.0.0.1:13000",
+		"OATS_OTLP_HTTP=http://127.0.0.1:14318",
+		"OATS_PYROSCOPE_URL=http://127.0.0.1:14040",
+	} {
+		if !containsString(got, want) {
+			t.Fatalf("k3dCheckEnv missing %q in %v", want, got)
+		}
+	}
+}
+
+func TestResolveComposeFiles_UnsupportedTemplate(t *testing.T) {
+	_, _, err := resolveComposeFiles(t.TempDir(), &casefile.ComposeFixture{Template: "weird"})
+	if err == nil || !strings.Contains(err.Error(), `unsupported compose template "weird"`) {
+		t.Fatalf("expected unsupported template error, got %v", err)
+	}
+}
+
+func TestResolveComposeFiles_TemplateNoneRequiresFile(t *testing.T) {
+	_, _, err := resolveComposeFiles(t.TempDir(), &casefile.ComposeFixture{Template: "none"})
+	if err == nil || !strings.Contains(err.Error(), "compose template=none requires file or files") {
+		t.Fatalf("expected template=none missing-file error, got %v", err)
+	}
+}
+
+func TestComposeFilePublishesFixedHostPorts(t *testing.T) {
+	dir := t.TempDir()
+	fixed := filepath.Join(dir, "fixed.yml")
+	random := filepath.Join(dir, "random.yml")
+	writeFile(t, dir, "fixed.yml", `services:
+  app:
+    image: alpine
+    ports:
+      - "8080:8080"
+`)
+	writeFile(t, dir, "random.yml", `services:
+  app:
+    image: alpine
+    ports:
+      - "8080"
+`)
+	got, err := composeFilePublishesFixedHostPorts(fixed)
+	if err != nil {
+		t.Fatalf("composeFilePublishesFixedHostPorts fixed: %v", err)
+	}
+	if !got {
+		t.Fatalf("expected fixed host port detection for %s", fixed)
+	}
+	got, err = composeFilePublishesFixedHostPorts(random)
+	if err != nil {
+		t.Fatalf("composeFilePublishesFixedHostPorts random: %v", err)
+	}
+	if got {
+		t.Fatalf("did not expect fixed host port detection for %s", random)
+	}
+}
+
+func TestSupportsParallel_ComposeTemplateLGTM(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "oats-config.yaml", `
+meta:
+  version: 3
+cases: ["cases/*.yaml"]
+`)
+	writeFile(t, dir, "cases/docker-compose.oats.yml", `services:
+  app:
+    image: alpine
+    command: ["sh", "-c", "sleep 1"]
+`)
+	writeFile(t, dir, "cases/a.yaml", `name: a
+fixture:
+  compose:
+    template: lgtm
+    file: docker-compose.oats.yml
+seed:
+  type: inline-otlp
+  logs:
+    - service: a
+      body: line
+expected:
+  logs:
+    - logql: '{service_name="a"}'
+      contains: line
+`)
+
+	cfg, err := discovery.Load(filepath.Join(dir, "oats-config.yaml"))
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	plans, err := cfg.PlanRun(discovery.Filter{})
+	if err != nil {
+		t.Fatalf("PlanRun: %v", err)
+	}
+	safe, reason := SupportsParallel(plans[0])
+	if !safe {
+		t.Fatalf("expected plan to be parallel-safe, got false: %s", reason)
+	}
+}
+
+// TestSupportsParallel_AppSeedRequiresAppService checks the gate that makes
+// app-seed compose suites parallel-safe: only when fixture.app_service and
+// app_port are set (so OATS can publish + discover an ephemeral app port) is the
+// suite safe; otherwise it would share a fixed app port with its peers.
+func TestSupportsParallel_AppSeedRequiresAppService(t *testing.T) {
+	appCase := &casefile.Case{Seed: casefile.Seed{Type: "app"}}
+
+	// app seed, no app_service → not parallel-safe.
+	noService := discovery.Plan{
+		Fixture: casefile.FixtureConfig{Compose: &casefile.ComposeFixture{Template: "lgtm"}},
+		Cases:   []*casefile.Case{appCase},
+	}
+	if safe, reason := SupportsParallel(noService); safe {
+		t.Fatalf("app-seed without app_service should not be parallel-safe, got safe (%s)", reason)
+	}
+
+	// app seed with app_service + app_port → parallel-safe.
+	withService := discovery.Plan{
+		Fixture: casefile.FixtureConfig{Compose: &casefile.ComposeFixture{Template: "lgtm", AppService: "app", AppPort: 8080}},
+		Cases:   []*casefile.Case{appCase},
+	}
+	if safe, reason := SupportsParallel(withService); !safe {
+		t.Fatalf("app-seed with app_service+app_port should be parallel-safe: %s", reason)
+	}
+}
+
+// TestWaitForGrafanaToken_DefaultFixtureReturnsEmpty exercises the token seam
+// for a fixture type that has no token to read: it returns immediately with an
+// empty token and no error.
+func TestWaitForGrafanaToken_DefaultFixtureReturnsEmpty(t *testing.T) {
+	token, err := waitForGrafanaToken(discovery.Plan{
+		Fixture: casefile.FixtureConfig{Remote: &casefile.RemoteFixture{}},
+	})
+	if err != nil {
+		t.Fatalf("waitForGrafanaToken: %v", err)
+	}
+	if token != "" {
+		t.Fatalf("expected empty token for remote fixture, got %q", token)
+	}
+}
+
+func writeFile(t *testing.T, dir, rel, body string) {
+	t.Helper()
+	p := filepath.Join(dir, rel)
+	if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(p, []byte(body), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+type fakeHandle struct {
+	upCalls    int
+	closeCalls int
+	upErr      error
+	closeErr   error
+}
+
+func (f *fakeHandle) Up() error {
+	f.upCalls++
+	return f.upErr
+}
+
+func (f *fakeHandle) Close() error {
+	f.closeCalls++
+	return f.closeErr
+}
+
+func equalStrings(got, want []string) bool {
+	if len(got) != len(want) {
+		return false
+	}
+	for i := range got {
+		if got[i] != want[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func containsString(items []string, want string) bool {
+	for _, item := range items {
+		if item == want {
+			return true
+		}
+	}
+	return false
+}

--- a/fixture/k3d.go
+++ b/fixture/k3d.go
@@ -1,0 +1,95 @@
+package fixture
+
+import (
+	"context"
+	"fmt"
+	"os/exec"
+
+	"github.com/grafana/oats/discovery"
+	"github.com/grafana/oats/runner"
+	"github.com/grafana/oats/testhelpers"
+	"github.com/grafana/oats/testhelpers/remote"
+)
+
+func startK3D(ctx context.Context, plan discovery.Plan) (Handle, Runtime, error) {
+	ports, err := allocateK3DPorts()
+	if err != nil {
+		return nil, Runtime{}, err
+	}
+	ep := newKubernetesEndpoint(plan, ports)
+	if err := ep.Start(ctx); err != nil {
+		_ = ep.Stop(context.Background())
+		return nil, Runtime{}, err
+	}
+	appPort := plan.Fixture.K3D.AppPort
+	rt := Runtime{
+		GrafanaURL:       fmt.Sprintf("http://%s:%d", testhelpers.LocalhostIPv4, ports.GrafanaHTTPPort),
+		OTLPHTTP:         fmt.Sprintf("http://%s:%d", testhelpers.LocalhostIPv4, ports.OTLPHTTPPort),
+		PyroscopeURL:     fmt.Sprintf("http://%s:%d", testhelpers.LocalhostIPv4, ports.PyroscopeHttpPort),
+		AppHostPort:      appPort,
+		CustomCheckEnv:   k3dCheckEnv(runner.Endpoint{AppHost: testhelpers.LocalhostIPv4, AppPort: appPort}, ports),
+		ParallelSafe:     false,
+		ParallelDisabled: "k3d fixtures currently use shared clusters and kubectl port-forwards",
+	}
+	cfg, cfgErr := writeLocalGCXConfig(rt.GrafanaURL)
+	if cfgErr != nil {
+		_ = ep.Stop(context.Background())
+		return nil, Runtime{}, fmt.Errorf("write local gcx config: %w", cfgErr)
+	}
+	rt.GCXConfig = cfg
+	return endpointFixture{ep: ep, cleanup: func() error { return removeIfExists(cfg) }}, rt, nil
+}
+
+func k3dCheckEnv(ep runner.Endpoint, ports remote.PortsConfig) []string {
+	return []string{
+		"OATS_FIXTURE_TYPE=k3d",
+		"OATS_APP_URL=" + fmt.Sprintf("http://%s:%d", ep.AppHost, ep.AppPort),
+		"OATS_GRAFANA_URL=" + fmt.Sprintf("http://%s:%d", testhelpers.LocalhostIPv4, ports.GrafanaHTTPPort),
+		"OATS_OTLP_HTTP=" + fmt.Sprintf("http://%s:%d", testhelpers.LocalhostIPv4, ports.OTLPHTTPPort),
+		"OATS_PYROSCOPE_URL=" + fmt.Sprintf("http://%s:%d", testhelpers.LocalhostIPv4, ports.PyroscopeHttpPort),
+	}
+}
+
+func allocateK3DPorts() (remote.PortsConfig, error) {
+	grafanaPort, err := findFreePort()
+	if err != nil {
+		return remote.PortsConfig{}, err
+	}
+	otlpHTTPPort, err := findFreePort()
+	if err != nil {
+		return remote.PortsConfig{}, err
+	}
+	lokiPort, err := findFreePort()
+	if err != nil {
+		return remote.PortsConfig{}, err
+	}
+	promPort, err := findFreePort()
+	if err != nil {
+		return remote.PortsConfig{}, err
+	}
+	tempoPort, err := findFreePort()
+	if err != nil {
+		return remote.PortsConfig{}, err
+	}
+	pyroscopePort, err := findFreePort()
+	if err != nil {
+		return remote.PortsConfig{}, err
+	}
+	return remote.PortsConfig{
+		GrafanaHTTPPort:    grafanaPort,
+		OTLPHTTPPort:       otlpHTTPPort,
+		LokiHttpPort:       lokiPort,
+		PrometheusHTTPPort: promPort,
+		TempoHTTPPort:      tempoPort,
+		PyroscopeHttpPort:  pyroscopePort,
+	}, nil
+}
+
+func readK3DGrafanaToken() (string, error) {
+	cmd := exec.Command("kubectl", "exec", "deploy/lgtm", "--", "sh", "-c", "cat /tmp/grafana-sa-token 2>/dev/null || true")
+	out, err := cmd.Output()
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/testhelpers/compose/compose.go
+++ b/testhelpers/compose/compose.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
-	"path"
 	"strings"
 	"sync"
 
@@ -20,29 +19,66 @@ import (
 type Compose struct {
 	Command     string
 	DefaultArgs []string
-	Path        string
+	Paths       []string
 	Env         []string
 }
+
+const composeCLIBinary = "docker"
+
+var dockerPruneMutex sync.Mutex
 
 func defaultEnv() []string {
 	return os.Environ()
 }
 
-func Suite(composeFile string) (*Compose, error) {
-	command := "docker"
-	defaultArgs := []string{"compose"}
+// mergeEnv combines the parent environment with explicitly provided vars,
+// ensuring the provided vars deterministically override any parent duplicates
+// (e.g. COMPOSE_PROJECT_NAME) regardless of platform-specific exec behavior.
+func mergeEnv(parent, override []string) []string {
+	merged := make([]string, 0, len(parent)+len(override))
+	index := make(map[string]int, len(parent)+len(override))
+	for _, kv := range append(append([]string{}, parent...), override...) {
+		key := kv
+		if i := strings.IndexByte(kv, '='); i >= 0 {
+			key = kv[:i]
+		}
+		if pos, ok := index[key]; ok {
+			merged[pos] = kv
+			continue
+		}
+		index[key] = len(merged)
+		merged = append(merged, kv)
+	}
+	return merged
+}
 
+func Suite(composeFile string) (*Compose, error) {
+	return SuiteFiles([]string{composeFile}, nil)
+}
+
+func SuiteFiles(composeFiles []string, env []string) (*Compose, error) {
+	defaultArgs := []string{"compose"}
+	for _, file := range composeFiles {
+		defaultArgs = append(defaultArgs, "-f", file)
+	}
+
+	if len(composeFiles) == 0 {
+		return nil, fmt.Errorf("at least one compose file is required")
+	}
+	mergedEnv := mergeEnv(defaultEnv(), env)
 	return &Compose{
-		Command:     command,
+		Command:     composeCLIBinary,
 		DefaultArgs: defaultArgs,
-		Path:        path.Join(composeFile),
-		Env:         defaultEnv(),
+		Paths:       composeFiles,
+		Env:         mergedEnv,
 	}, nil
 }
 
 func (c *Compose) Up() error {
 	// networks accumulate over time and can cause issues with the tests
+	dockerPruneMutex.Lock()
 	err := c.runDocker(newCommand("network", "prune", "-f", "--filter", "until=5m").withCompose(false))
+	dockerPruneMutex.Unlock()
 	if err != nil {
 		return fmt.Errorf("failed to prune docker networks: %w", err)
 	}
@@ -69,43 +105,72 @@ func (c *Compose) Remove() error {
 func (c *Compose) runDocker(cc command) error {
 	var cmdArgs []string
 	if cc.compose {
-		cmdArgs = c.DefaultArgs
-		cmdArgs = append(cmdArgs, "-f", c.Path)
+		cmdArgs = append([]string(nil), c.DefaultArgs...)
 	}
 	cmdArgs = append(cmdArgs, cc.args...)
 	cmd := exec.Command(c.Command, cmdArgs...)
 	cmd.Env = c.Env
 	if cc.logConsumer != nil {
-		stdout, _ := cmd.StdoutPipe()
+		stdout, err := cmd.StdoutPipe()
+		if err != nil {
+			return fmt.Errorf("failed to open docker stdout pipe: %w", err)
+		}
 		cmd.Stderr = cmd.Stdout
+		// Start before spawning the consumer: if Start fails the write end of
+		// the pipe never opens, so a consumer started earlier would block on
+		// the read forever and leak.
+		if err := cmd.Start(); err != nil {
+			_ = stdout.Close()
+			return fmt.Errorf("failed to start docker command: %w", err)
+		}
 		wg := sync.WaitGroup{}
 		wg.Add(1)
 		go cc.logConsumer(stdout, &wg)
-
-		err := cmd.Start()
+		wg.Wait()
+		if err := cmd.Wait(); err != nil {
+			return fmt.Errorf("failed to run docker command: %w", err)
+		}
+	} else if cc.background {
+		slog.Info("Running", "command", cmd.String(), "compose_files", c.Paths)
+		stdout, err := cmd.StdoutPipe()
 		if err != nil {
+			return fmt.Errorf("failed to open docker stdout pipe: %w", err)
+		}
+		cmd.Stderr = cmd.Stdout
+		// Start the command before spawning the reader: if Start fails the
+		// write end of the pipe never opens, and a reader started earlier would
+		// block forever on ReadString and leak.
+		if err := cmd.Start(); err != nil {
+			_ = stdout.Close()
 			return fmt.Errorf("failed to start docker command: %w", err)
 		}
-		wg.Wait()
-	} else if cc.background {
-		slog.Info("Running", "command", cmd.String(), "dir", c.Path)
-		stdout, _ := cmd.StdoutPipe()
-		cmd.Stderr = cmd.Stdout
+		wg := sync.WaitGroup{}
+		wg.Add(1)
 		go func() {
+			defer wg.Done()
 			reader := bufio.NewReader(stdout)
-			line, err := reader.ReadString('\n')
-			for err == nil {
-				slog.Info(line)
-				line, err = reader.ReadString('\n')
+			for {
+				// ReadString returns any final data together with io.EOF, so
+				// log the chunk before checking err to avoid dropping a
+				// trailing line without a newline. Reading to EOF also fully
+				// drains the pipe so the child never blocks on a full pipe.
+				line, err := reader.ReadString('\n')
+				if line != "" {
+					slog.Info(line)
+				}
+				if err != nil {
+					return
+				}
 			}
 		}()
 
-		err := cmd.Start()
+		err = cmd.Wait()
+		wg.Wait()
 		if err != nil {
-			return fmt.Errorf("failed to start docker command: %w", err)
+			return fmt.Errorf("failed to run docker command: %w", err)
 		}
 	} else {
-		slog.Info("Running", "command", cmd.String(), "dir", c.Path)
+		slog.Info("Running", "command", cmd.String(), "compose_files", c.Paths)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		err := cmd.Run()

--- a/testhelpers/kubernetes/kubernetes.go
+++ b/testhelpers/kubernetes/kubernetes.go
@@ -2,13 +2,17 @@ package kubernetes
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
 	"os"
 	"os/exec"
+	"strings"
 	"sync"
+	"unicode"
 
+	"github.com/grafana/oats/testhelpers"
 	"github.com/grafana/oats/testhelpers/remote"
 )
 
@@ -22,8 +26,17 @@ type Kubernetes struct {
 	ImportImages     []string `yaml:"import-images"`
 }
 
+const (
+	kubernetesCLIBinary = "kubectl"
+	k3dCLIBinary        = "k3d"
+	dockerCLIBinary     = "docker"
+
+	defaultAppRemotePort = 8080
+)
+
 func NewEndpoint(host string, model *Kubernetes, ports remote.PortsConfig, testName string, dir string) *remote.Endpoint {
 	var killList []*os.Process
+	cluster := clusterName(testName)
 	run := func(cmd *exec.Cmd, background bool) error {
 		slog.Info("running", "command", cmd.String(), "dir", dir)
 		cmd.Stdout = os.Stdout
@@ -42,16 +55,21 @@ func NewEndpoint(host string, model *Kubernetes, ports remote.PortsConfig, testN
 	return remote.NewEndpoint(host, ports, func(ctx context.Context) error {
 		return start(model, ports, testName, run)
 	}, func(ctx context.Context) error {
+		var errs []error
 		for _, p := range killList {
-			err := p.Kill()
-			if err != nil {
-				return err
+			// A port-forward that already exited returns os.ErrProcessDone;
+			// that means cleanup is already done, not a teardown failure.
+			if err := p.Kill(); err != nil && !errors.Is(err, os.ErrProcessDone) {
+				errs = append(errs, err)
 			}
 		}
-		return run(exec.Command("k3d", "cluster", "delete", testName), false)
+		if err := run(exec.Command(k3dCLIBinary, "cluster", "delete", cluster), false); err != nil {
+			errs = append(errs, err)
+		}
+		return errors.Join(errs...)
 	},
 		func(f func(io.ReadCloser, *sync.WaitGroup)) error {
-			panic("not implemented for kubernetes")
+			return fmt.Errorf("compose log reading is not implemented for kubernetes fixtures")
 		},
 	)
 }
@@ -66,44 +84,41 @@ func start(model *Kubernetes, ports remote.PortsConfig, testName string, run fun
 		model.AppDockerContext = "."
 	}
 
-	err := run(exec.Command("docker", "build", "-f", model.AppDockerFile, "-t", model.AppDockerTag, model.AppDockerContext), false)
+	err := run(exec.Command(dockerCLIBinary, "build", "-f", model.AppDockerFile, "-t", model.AppDockerTag, model.AppDockerContext), false)
 	if err != nil {
 		return err
 	}
 
-	cluster := testName
-	if len(cluster) > 32 {
-		cluster = cluster[(len(cluster))-32:]
-	}
+	cluster := clusterName(testName)
 
-	err = run(exec.Command("k3d", "cluster", "list", cluster), false)
+	err = run(exec.Command(k3dCLIBinary, "cluster", "list", cluster), false)
 	if err == nil {
 		slog.Info("cluster already exists - deleting", "name", cluster)
-		err = run(exec.Command("k3d", "cluster", "delete", cluster), false)
+		err = run(exec.Command(k3dCLIBinary, "cluster", "delete", cluster), false)
 		if err != nil {
 			return err
 		}
 	}
 
-	err = run(exec.Command("k3d", "cluster", "create", cluster), false)
+	err = run(exec.Command(k3dCLIBinary, "cluster", "create", cluster), false)
 	if err != nil {
 		return err
 	}
 	importImages := []string{model.AppDockerTag}
 	importImages = append(importImages, model.ImportImages...)
 	for _, image := range importImages {
-		err = run(exec.Command("k3d", "image", "import", "-c", cluster, image), false)
+		err = run(exec.Command(k3dCLIBinary, "image", "import", "-c", cluster, image), false)
 		if err != nil {
 			return err
 		}
 	}
-	err = run(exec.Command("kubectl", "apply", "-f", model.Dir), false)
+	err = run(exec.Command(kubernetesCLIBinary, "apply", "-f", model.Dir), false)
 	if err != nil {
 		return err
 	}
 	err = run(
 		exec.Command(
-			"kubectl",
+			kubernetesCLIBinary,
 			"wait",
 			"--timeout=5m",
 			"--for=condition=available",
@@ -114,26 +129,71 @@ func start(model *Kubernetes, ports remote.PortsConfig, testName string, run fun
 	if err != nil {
 		return err
 	}
-	err = run(exec.Command("kubectl", "port-forward", "service/"+model.AppService, fmt.Sprintf("%d:8080", model.AppDockerPort)), true)
+	err = run(exec.Command(kubernetesCLIBinary, "port-forward", "service/"+model.AppService, fmt.Sprintf("%d:%d", model.AppDockerPort, defaultAppRemotePort)), true)
 	if err != nil {
 		return err
 	}
 
-	err = portForward(ports.LokiHttpPort, 3100)
+	err = portForward(ports.LokiHttpPort, testhelpers.LokiHTTPPort)
 	if err != nil {
 		return err
 	}
-	err = portForward(ports.PrometheusHTTPPort, 9090)
+	if ports.GrafanaHTTPPort != 0 {
+		err = portForward(ports.GrafanaHTTPPort, testhelpers.GrafanaHTTPPort)
+		if err != nil {
+			return err
+		}
+	}
+	if ports.OTLPHTTPPort != 0 {
+		err = portForward(ports.OTLPHTTPPort, testhelpers.OTLPHTTPPort)
+		if err != nil {
+			return err
+		}
+	}
+	err = portForward(ports.PrometheusHTTPPort, testhelpers.PrometheusHTTPPort)
 	if err != nil {
 		return err
 	}
-	err = portForward(ports.TempoHTTPPort, 3200)
+	err = portForward(ports.TempoHTTPPort, testhelpers.TempoHTTPPort)
 	if err != nil {
 		return err
 	}
-	err = portForward(ports.PyroscopeHttpPort, 4040)
+	err = portForward(ports.PyroscopeHttpPort, testhelpers.PyroscopeHTTPPort)
 	if err != nil {
 		return err
 	}
 	return nil
+}
+
+func clusterName(testName string) string {
+	var b strings.Builder
+	lastDash := false
+	for _, r := range strings.ToLower(testName) {
+		switch {
+		case (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9'):
+			b.WriteRune(r)
+			lastDash = false
+		case r == '-' || r == '_' || unicode.IsSpace(r):
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		default:
+			if !lastDash && b.Len() > 0 {
+				b.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	cluster := strings.Trim(b.String(), "-")
+	if cluster == "" {
+		cluster = "oats"
+	}
+	if len(cluster) > 32 {
+		cluster = strings.Trim(cluster[len(cluster)-32:], "-")
+		if cluster == "" {
+			cluster = "oats"
+		}
+	}
+	return cluster
 }

--- a/testhelpers/kubernetes/kubernetes_test.go
+++ b/testhelpers/kubernetes/kubernetes_test.go
@@ -2,11 +2,90 @@ package kubernetes
 
 import (
 	"os/exec"
+	"reflect"
+	"strings"
 	"testing"
 
 	"github.com/grafana/oats/testhelpers/remote"
 	"github.com/stretchr/testify/require"
 )
+
+func TestClusterName_TruncatesFromEnd(t *testing.T) {
+	in := "this-is-a-very-long-suite-name-that-exceeds-thirty-two-chars"
+	got := clusterName(in)
+	if len(got) != 32 {
+		t.Fatalf("cluster length = %d, want 32 (%q)", len(got), got)
+	}
+	if !strings.HasSuffix(in, got) {
+		t.Fatalf("expected %q to be the suffix of %q", got, in)
+	}
+}
+
+func TestClusterName_NormalizesRFC1123(t *testing.T) {
+	if got := clusterName("logging k8s probe"); got != "logging-k8s-probe" {
+		t.Fatalf("clusterName() = %q, want %q", got, "logging-k8s-probe")
+	}
+	if got := clusterName("!!!"); got != "oats" {
+		t.Fatalf("clusterName() fallback = %q, want %q", got, "oats")
+	}
+}
+
+func TestStart_DefaultDockerContextAndCommandSequence(t *testing.T) {
+	model := &Kubernetes{
+		Dir:           "k8s",
+		AppService:    "dice",
+		AppDockerFile: "Dockerfile",
+		AppDockerTag:  "dice:test",
+		AppDockerPort: 18080,
+		ImportImages:  []string{"busybox:latest"},
+	}
+	ports := remote.PortsConfig{
+		GrafanaHTTPPort:    13000,
+		OTLPHTTPPort:       14318,
+		PrometheusHTTPPort: 19090,
+		LokiHttpPort:       13100,
+		TempoHTTPPort:      13200,
+		PyroscopeHttpPort:  14040,
+	}
+
+	var calls []string
+	run := func(cmd *exec.Cmd, background bool) error {
+		mode := "fg"
+		if background {
+			mode = "bg"
+		}
+		calls = append(calls, mode+": "+strings.Join(cmd.Args, " "))
+		return nil
+	}
+
+	if err := start(model, ports, "smoke-suite", run); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	if model.AppDockerContext != "." {
+		t.Fatalf("expected default docker context '.', got %q", model.AppDockerContext)
+	}
+
+	want := []string{
+		"fg: docker build -f Dockerfile -t dice:test .",
+		"fg: k3d cluster list smoke-suite",
+		"fg: k3d cluster delete smoke-suite",
+		"fg: k3d cluster create smoke-suite",
+		"fg: k3d image import -c smoke-suite dice:test",
+		"fg: k3d image import -c smoke-suite busybox:latest",
+		"fg: kubectl apply -f k8s",
+		"fg: kubectl wait --timeout=5m --for=condition=available deployment/lgtm",
+		"bg: kubectl port-forward service/dice 18080:8080",
+		"bg: kubectl port-forward service/lgtm 13100:3100",
+		"bg: kubectl port-forward service/lgtm 13000:3000",
+		"bg: kubectl port-forward service/lgtm 14318:4318",
+		"bg: kubectl port-forward service/lgtm 19090:9090",
+		"bg: kubectl port-forward service/lgtm 13200:3200",
+		"bg: kubectl port-forward service/lgtm 14040:4040",
+	}
+	if !reflect.DeepEqual(calls, want) {
+		t.Fatalf("unexpected command sequence:\n got: %#v\nwant: %#v", calls, want)
+	}
+}
 
 func TestStartWaitsForLgtmDeploymentAvailability(t *testing.T) {
 	t.Parallel()
@@ -20,6 +99,8 @@ func TestStartWaitsForLgtmDeploymentAvailability(t *testing.T) {
 		AppDockerPort:    8080,
 	}
 	ports := remote.PortsConfig{
+		GrafanaHTTPPort:    3000,
+		OTLPHTTPPort:       4318,
 		LokiHttpPort:       3100,
 		PrometheusHTTPPort: 9090,
 		TempoHTTPPort:      3200,
@@ -42,4 +123,42 @@ func TestStartWaitsForLgtmDeploymentAvailability(t *testing.T) {
 		"--for=condition=available",
 		"deployment/lgtm",
 	})
+}
+
+func TestStart_SkipsGrafanaAndOTLPPortsWhenUnset(t *testing.T) {
+	t.Parallel()
+
+	model := &Kubernetes{
+		Dir:              "k8s",
+		AppService:       "dice",
+		AppDockerFile:    "Dockerfile",
+		AppDockerContext: ".",
+		AppDockerTag:     "dice:test",
+		AppDockerPort:    18080,
+	}
+	ports := remote.PortsConfig{
+		LokiHttpPort:       3100,
+		PrometheusHTTPPort: 9090,
+		TempoHTTPPort:      3200,
+		PyroscopeHttpPort:  4040,
+	}
+
+	var calls []string
+	run := func(cmd *exec.Cmd, background bool) error {
+		mode := "fg"
+		if background {
+			mode = "bg"
+		}
+		calls = append(calls, mode+": "+strings.Join(cmd.Args, " "))
+		return nil
+	}
+
+	if err := start(model, ports, "legacy-ports", run); err != nil {
+		t.Fatalf("start: %v", err)
+	}
+	for _, call := range calls {
+		if strings.Contains(call, ":3000") || strings.Contains(call, ":4318") {
+			t.Fatalf("expected no Grafana/OTLP port-forward when ports are unset, got %#v", calls)
+		}
+	}
 }

--- a/testhelpers/ports.go
+++ b/testhelpers/ports.go
@@ -1,0 +1,13 @@
+package testhelpers
+
+const (
+	LocalhostIPv4 = "127.0.0.1"
+
+	GrafanaHTTPPort    = 3000
+	LokiHTTPPort       = 3100
+	OTLPGRPCPort       = 4317
+	OTLPHTTPPort       = 4318
+	TempoHTTPPort      = 3200
+	PyroscopeHTTPPort  = 4040
+	PrometheusHTTPPort = 9090
+)

--- a/testhelpers/remote/remote_observability_endpoint.go
+++ b/testhelpers/remote/remote_observability_endpoint.go
@@ -21,11 +21,30 @@ import (
 type PortsConfig struct {
 	TracesGRPCPort     int
 	TracesHTTPPort     int
+	GrafanaHTTPPort    int
+	OTLPHTTPPort       int
 	TempoHTTPPort      int
 	MimirHTTPPort      int
 	PrometheusHTTPPort int
 	LokiHttpPort       int
 	PyroscopeHttpPort  int
+}
+
+func (p PortsConfig) EffectiveGrafanaHTTPPort() int {
+	if p.GrafanaHTTPPort != 0 {
+		return p.GrafanaHTTPPort
+	}
+	return 3000
+}
+
+func (p PortsConfig) EffectiveOTLPHTTPPort() int {
+	if p.OTLPHTTPPort != 0 {
+		return p.OTLPHTTPPort
+	}
+	if p.TracesHTTPPort != 0 {
+		return p.TracesHTTPPort
+	}
+	return 4318
 }
 
 type Endpoint struct {


### PR DESCRIPTION
Part **5/8** of splitting #334. Stacked on #371.

## What
`fixture`: fixture lifecycle for Docker Compose and k3d/Kubernetes backends (build, boot, teardown), plus `testhelpers/{compose,kubernetes,remote}` support.

## Depends on
#371
