### PR TITLE
refactor(report): rename suites to fixture groups

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -14,7 +14,7 @@ The root `oats` binary now runs the gcx-driven current CLI only.
 
 That means upgrades now require migrating to the current:
 
-- `oats-config.yaml` suite/discovery file
+- `oats-config.yaml` case-discovery file
 - current case yaml shape documented in [docs/case-reference.md](docs/case-reference.md)
 
 The legacy "pass one or more old yaml files directly to `oats`" runner has been
@@ -133,14 +133,8 @@ case (the migrator prints both the case yaml and a suggested `fixture:` block):
 # oats-config.yaml
 meta:
   version: 3
-suites:
-  - name: rolldice
-    cases: ["cases/*.yaml"]
-    fixture: compose-lgtm
-fixture:
-  compose-lgtm:
-    compose:
-      file: docker-compose.yaml
+cases:
+  - cases/rolldice.yaml
 ```
 
 ```yaml

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -24,7 +24,7 @@ oats                              # run every case
 oats payments/                    # only cases under payments/
 oats payments/checkout/           # only cases under payments/checkout/
 oats --tags traces                # filter by tag
-oats --parallel 4                 # run parallel-safe suites concurrently
+oats --parallel 4                 # run parallel-safe fixture groups concurrently
 ```
 
 A run boots each derived fixture group, seeds it, then polls every assertion

--- a/examples/fixtures/compose/rolldice/oats-case.yaml
+++ b/examples/fixtures/compose/rolldice/oats-case.yaml
@@ -2,7 +2,7 @@
 # for readiness, then tears them down. A compose fixture defaults to
 # `template: lgtm`, so OATS boots a grafana/otel-lgtm stack alongside these files
 # — that's the `lgtm` service the env below points at. Set `template: none` to
-# bring your own stack. Every case in a suite must declare the same fixture.
+# bring your own stack. Every case in a fixture group must declare the same fixture.
 name: compose fixture app smoke
 tags: [compose, app]   # filter with `oats --tags compose`
 

--- a/examples/fixtures/k3d/rolldice/oats-case.yaml
+++ b/examples/fixtures/k3d/rolldice/oats-case.yaml
@@ -1,6 +1,6 @@
 # Boots a k3d fixture: OATS spins up a k3d (k3s-in-docker) cluster, builds +
 # imports the app image, applies the manifests in k8s_dir, and port-forwards to
-# reach it. Every case in a suite must declare the same fixture.
+# reach it. Every case in a fixture group must declare the same fixture.
 name: k3d fixture app smoke
 tags: [k3d, app]   # filter with `oats --tags k3d`
 

--- a/examples/fixtures/oats-config.yaml
+++ b/examples/fixtures/oats-config.yaml
@@ -6,7 +6,7 @@
 meta:
   version: 3
 
-# Just list the cases — there is no suite/grouping to declare. Each case carries
+# Just list the cases — there is no explicit grouping to declare. Each case carries
 # its own fixture (see the `fixture:` block in each oats-case.yaml), and OATS
 # groups cases by fixture: the compose case and the k3d case declare different
 # fixtures, so they become two independent boot-groups (each fixture booted once,

--- a/examples/python/docker-compose.oats.yml
+++ b/examples/python/docker-compose.oats.yml
@@ -11,6 +11,6 @@ services:
       OTEL_EXPORTER_OTLP_ENDPOINT: http://lgtm:4317
       OTEL_METRIC_EXPORT_INTERVAL: "5000" # so we don't wait 60s for metrics
     ports:
-      # Ephemeral host port so parallel suites don't collide; OATS discovers it
+      # Ephemeral host port so parallel fixture groups don't collide; OATS discovers it
       # via fixture.app_service + app_port.
       - "127.0.0.1::8082"

--- a/examples/smoke/oats-config.yaml
+++ b/examples/smoke/oats-config.yaml
@@ -1,7 +1,7 @@
 # oats-config.yaml is the entry point of an OATS project. `oats` finds it in the
 # current directory or any parent, and lists the case files to run.
 #
-# There is no suite/grouping to declare: each case carries its own fixture, and
+# There is no explicit grouping to declare: each case carries its own fixture, and
 # OATS boots each distinct fixture once and runs the cases that share it against
 # it (distinct fixtures can run in parallel). Every case here points at the same
 # remote grafana/otel-lgtm, so they form one group — but a remote fixture boots

--- a/fixture/compose.go
+++ b/fixture/compose.go
@@ -30,38 +30,38 @@ func startCompose(plan discovery.Plan) (Handle, Runtime, error) {
 		return nil, Runtime{}, err
 	}
 	project := composeProjectName(plan)
-	suiteEnv := append([]string(nil), compose.Env...)
-	suiteEnv = append(suiteEnv, "COMPOSE_PROJECT_NAME="+project)
-	suite, err := newComposeSuite(composeFiles, suiteEnv)
+	composeEnv := append([]string(nil), compose.Env...)
+	composeEnv = append(composeEnv, "COMPOSE_PROJECT_NAME="+project)
+	stack, err := newComposeStack(composeFiles, composeEnv)
 	if err != nil {
 		if cleanup != nil {
 			_ = cleanup()
 		}
 		return nil, Runtime{}, err
 	}
-	if err := startSuiteFixture(suite); err != nil {
+	if err := startFixture(stack); err != nil {
 		if cleanup != nil {
 			_ = cleanup()
 		}
 		return nil, Runtime{}, err
 	}
-	// fail tears the started suite (and any file cleanup) down before returning.
+	// fail tears the started stack (and any file cleanup) down before returning.
 	fail := func(err error) (Handle, Runtime, error) {
-		_ = suite.Close()
+		_ = stack.Close()
 		if cleanup != nil {
 			_ = cleanup()
 		}
 		return nil, Runtime{}, err
 	}
-	grafanaPort, err := lookupComposePort(composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.GrafanaHTTPPort))
+	grafanaPort, err := lookupComposePort(composeFiles, composeEnv, lgtmComposeService, portString(testhelpers.GrafanaHTTPPort))
 	if err != nil {
 		return fail(err)
 	}
-	otlpPort, err := lookupComposePort(composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.OTLPHTTPPort))
+	otlpPort, err := lookupComposePort(composeFiles, composeEnv, lgtmComposeService, portString(testhelpers.OTLPHTTPPort))
 	if err != nil {
 		return fail(err)
 	}
-	pyroscopePort, err := lookupComposePort(composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.PyroscopeHTTPPort))
+	pyroscopePort, err := lookupComposePort(composeFiles, composeEnv, lgtmComposeService, portString(testhelpers.PyroscopeHTTPPort))
 	if err != nil {
 		return fail(err)
 	}
@@ -75,9 +75,9 @@ func startCompose(plan discovery.Plan) (Handle, Runtime, error) {
 	// When the fixture manages the app (app_service + app_port), resolve the host
 	// port docker published for it. This lets the app bind an ephemeral host port
 	// (127.0.0.1::<port>) instead of a fixed one, which is what makes app-seed
-	// suites parallel-safe.
+	// fixture groups parallel-safe.
 	if plan.Fixture.HasManagedApp() {
-		appPort, portErr := lookupComposePort(composeFiles, suiteEnv, compose.AppService, strconv.Itoa(compose.AppPort))
+		appPort, portErr := lookupComposePort(composeFiles, composeEnv, compose.AppService, strconv.Itoa(compose.AppPort))
 		if portErr != nil {
 			return fail(fmt.Errorf("resolve app host port for service %q: %w", compose.AppService, portErr))
 		}
@@ -95,7 +95,7 @@ func startCompose(plan discovery.Plan) (Handle, Runtime, error) {
 	cleanup = chainCleanup(func() error { return removeIfExists(cfg) }, cleanup)
 	rt.CustomCheckEnv = composeCheckEnv(plan, rt)
 	rt.ParallelSafe, rt.ParallelDisabled = SupportsParallel(plan)
-	return composeFixture{suite: suite, cleanup: cleanup}, rt, nil
+	return composeFixture{stack: stack, cleanup: cleanup}, rt, nil
 }
 
 func resolveComposeFiles(sourceDir string, compose *casefile.ComposeFixture) ([]string, func() error, error) {

--- a/fixture/fixture.go
+++ b/fixture/fixture.go
@@ -1,7 +1,7 @@
-// Package fixture owns the lifecycle of the observability backends a suite
+// Package fixture owns the lifecycle of the observability backends a fixture group
 // runs against: booting a docker-compose or k3d stack, waiting for it to be
 // ready, exposing the resolved endpoints as a Runtime, and tearing it down.
-// The CLI orchestrates suites and reporting; this package abstracts "stand up
+// The CLI orchestrates fixture groups and reporting; this package abstracts "stand up
 // the stack the cases need" behind a small, pluggable surface.
 package fixture
 
@@ -23,8 +23,8 @@ import (
 
 // Seams overridable in tests.
 var (
-	newComposeSuite = func(files []string, env []string) (Handle, error) {
-		return compose.SuiteFiles(files, env)
+	newComposeStack = func(files []string, env []string) (Handle, error) {
+		return compose.StackFiles(files, env)
 	}
 	newKubernetesEndpoint = func(plan discovery.Plan, ports remote.PortsConfig) *remote.Endpoint {
 		sourceDir := plan.FixtureSourceDir
@@ -104,8 +104,8 @@ func WaitForReady(plan discovery.Plan, rt Runtime) error {
 	return nil
 }
 
-// SupportsParallel reports whether a suite on this fixture can run alongside
-// other suites, and if not, a human-readable reason.
+// SupportsParallel reports whether a fixture group on this fixture can run
+// alongside other groups, and if not, a human-readable reason.
 func SupportsParallel(plan discovery.Plan) (bool, string) {
 	switch plan.Fixture.Kind() {
 	case "", "remote":
@@ -119,9 +119,9 @@ func SupportsParallel(plan discovery.Plan) (bool, string) {
 			// ephemeral host port instead of a shared fixed one — which requires
 			// fixture.app_service (+ app_port) so the published port can be
 			// discovered. Without it the app falls back to the fixed --app-port
-			// and parallel suites would collide.
+			// and parallel groups would collide.
 			if c.Seed.EffectiveType() == "app" && !plan.Fixture.HasManagedApp() {
-				return false, "compose app-seed suites need fixture.app_service and app_port so OATS can publish an ephemeral app port; otherwise they share a fixed app port"
+				return false, "compose app-seed groups need fixture.app_service and app_port so OATS can publish an ephemeral app port; otherwise they share a fixed app port"
 			}
 		}
 		for _, file := range extraComposeFiles(plan) {
@@ -139,7 +139,7 @@ func SupportsParallel(plan discovery.Plan) (bool, string) {
 	}
 }
 
-func startSuiteFixture(fix Handle) error {
+func startFixture(fix Handle) error {
 	startable, ok := fix.(startableHandle)
 	if !ok {
 		return fmt.Errorf("fixture does not support startup")
@@ -163,12 +163,12 @@ func (e endpointFixture) Close() error {
 }
 
 type composeFixture struct {
-	suite   Handle
+	stack   Handle
 	cleanup func() error
 }
 
 func (c composeFixture) Close() error {
-	err := c.suite.Close()
+	err := c.stack.Close()
 	if c.cleanup != nil {
 		if cleanupErr := c.cleanup(); cleanupErr != nil && err == nil {
 			err = cleanupErr

--- a/fixture/fixture_test.go
+++ b/fixture/fixture_test.go
@@ -77,14 +77,14 @@ func TestResolveComposeFiles(t *testing.T) {
 }
 
 func TestStart_ComposeLifecycle(t *testing.T) {
-	oldFactory := newComposeSuite
+	oldFactory := newComposeStack
 	oldLookup := lookupComposePort
-	defer func() { newComposeSuite = oldFactory }()
+	defer func() { newComposeStack = oldFactory }()
 	defer func() { lookupComposePort = oldLookup }()
 
 	var gotFiles, gotEnv []string
 	fake := &fakeHandle{}
-	newComposeSuite = func(files []string, env []string) (Handle, error) {
+	newComposeStack = func(files []string, env []string) (Handle, error) {
 		gotFiles = append([]string(nil), files...)
 		gotEnv = append([]string(nil), env...)
 		return fake, nil
@@ -137,10 +137,10 @@ func TestStart_ComposeLifecycle(t *testing.T) {
 }
 
 func TestStart_ComposeStartFailure(t *testing.T) {
-	oldFactory := newComposeSuite
-	defer func() { newComposeSuite = oldFactory }()
+	oldFactory := newComposeStack
+	defer func() { newComposeStack = oldFactory }()
 
-	newComposeSuite = func(files []string, env []string) (Handle, error) {
+	newComposeStack = func(files []string, env []string) (Handle, error) {
 		return &fakeHandle{upErr: fmt.Errorf("boom")}, nil
 	}
 
@@ -350,9 +350,9 @@ expected:
 }
 
 // TestSupportsParallel_AppSeedRequiresAppService checks the gate that makes
-// app-seed compose suites parallel-safe: only when fixture.app_service and
+// app-seed compose groups parallel-safe: only when fixture.app_service and
 // app_port are set (so OATS can publish + discover an ephemeral app port) is the
-// suite safe; otherwise it would share a fixed app port with its peers.
+// group safe; otherwise it would share a fixed app port with its peers.
 func TestSupportsParallel_AppSeedRequiresAppService(t *testing.T) {
 	appCase := &casefile.Case{Seed: casefile.Seed{Type: "app"}}
 

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -68,7 +68,7 @@ func TestCloseFixture_EmitsTeardownEvent(t *testing.T) {
 	if len(rep.events) != 1 || rep.events[0].Type != report.EventFixtureTeardown {
 		t.Fatalf("expected one teardown event, got %+v", rep.events)
 	}
-	if rep.events[0].Suite != "smoke" || rep.events[0].FixtureType != "compose" {
+	if rep.events[0].Group != "smoke" || rep.events[0].FixtureType != "compose" {
 		t.Fatalf("unexpected teardown event: %+v", rep.events[0])
 	}
 }
@@ -104,7 +104,7 @@ func TestEmitFixtureStartAndReady(t *testing.T) {
 	if len(rep.events) != 1 || rep.events[0].Type != report.EventFixtureStart {
 		t.Fatalf("expected one fixture.start event, got %+v", rep.events)
 	}
-	if rep.events[0].Suite != "smoke" || rep.events[0].FixtureType != "compose" {
+	if rep.events[0].Group != "smoke" || rep.events[0].FixtureType != "compose" {
 		t.Fatalf("unexpected fixture.start event: %+v", rep.events[0])
 	}
 

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -63,7 +63,7 @@ var Version = "dev"
 // when gcx is not already available on PATH.
 var DefaultGCXVersion = ""
 
-type suiteResult struct {
+type groupResult struct {
 	pass int
 	fail int
 	err  error
@@ -452,7 +452,7 @@ func resolveEndpoint(plan discovery.Plan, rt fixture.Runtime, gcxContextOverride
 	switch plan.Fixture.Kind() {
 	case "remote":
 		// For a remote fixture, the gcx context is configured externally
-		// (e.g. `gcx login` already ran). We pass the suite name as a
+		// (e.g. `gcx login` already ran). We pass the fixture-group name as a
 		// best-effort default; --gcx-context overrides.
 		ep.GCXContext = plan.Name
 		ep.OTLPHTTP = plan.Fixture.Remote.Endpoint
@@ -565,7 +565,7 @@ func runPlansParallel(parent context.Context, rep report.Reporter, plans []disco
 	defer cancel()
 
 	workCh := make(chan discovery.Plan)
-	resultCh := make(chan suiteResult, len(plans))
+	resultCh := make(chan groupResult, len(plans))
 	workers := parallel
 	if workers > len(plans) {
 		workers = len(plans)
@@ -614,17 +614,17 @@ func runPlansParallel(parent context.Context, rep report.Reporter, plans []disco
 	return totalPass, totalFail, firstErr
 }
 
-func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts runOptions) suiteResult {
+func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts runOptions) groupResult {
 	fixtureStart := emitFixtureStart(rep, plan)
 	fix, rt, err := fixture.Start(ctx, plan)
 	if err != nil {
-		return suiteResult{err: fmt.Errorf("suite %q: %w", plan.Name, err)}
+		return groupResult{err: fmt.Errorf("fixture group %q: %w", plan.Name, err)}
 	}
 	if err := fixture.WaitForReady(plan, rt); err != nil {
 		if fix != nil {
 			_ = closeFixture(rep, plan, fix)
 		}
-		return suiteResult{err: fmt.Errorf("suite %q: %w", plan.Name, err)}
+		return groupResult{err: fmt.Errorf("fixture group %q: %w", plan.Name, err)}
 	}
 	emitFixtureReady(rep, plan, fixtureStart)
 	ep, err := resolveEndpoint(plan, rt, opts.gcxContextOverride, opts.appHost, opts.appPort, opts.otlpHTTP)
@@ -632,12 +632,12 @@ func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts
 		if fix != nil {
 			_ = closeFixture(rep, plan, fix)
 		}
-		return suiteResult{err: fmt.Errorf("suite %q: %w", plan.Name, err)}
+		return groupResult{err: fmt.Errorf("fixture group %q: %w", plan.Name, err)}
 	}
 
 	rep.Emit(report.Event{
-		Type:        report.EventSuiteStart,
-		Suite:       plan.Name,
+		Type:        report.EventGroupStart,
+		Group:       plan.Name,
 		FixtureType: plan.Fixture.Kind(),
 		CaseCount:   len(plan.Cases),
 	})
@@ -664,15 +664,15 @@ func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts
 		}
 	}
 
-	var suitePass, suiteFail int
+	var groupPass, groupFail int
 	for _, c := range plan.Cases {
 		if ctx.Err() != nil {
 			break
 		}
 		if r.RunCase(ctx, c) {
-			suitePass++
+			groupPass++
 		} else {
-			suiteFail++
+			groupFail++
 			if opts.failFast {
 				break
 			}
@@ -680,17 +680,17 @@ func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts
 	}
 
 	rep.Emit(report.Event{
-		Type:  report.EventSuiteEnd,
-		Suite: plan.Name,
-		Pass:  suitePass,
-		Fail:  suiteFail,
+		Type:  report.EventGroupEnd,
+		Group: plan.Name,
+		Pass:  groupPass,
+		Fail:  groupFail,
 	})
 	if fix != nil {
 		if closeErr := closeFixture(rep, plan, fix); closeErr != nil {
-			return suiteResult{pass: suitePass, fail: suiteFail, err: fmt.Errorf("suite %q: fixture shutdown: %w", plan.Name, closeErr)}
+			return groupResult{pass: groupPass, fail: groupFail, err: fmt.Errorf("fixture group %q: fixture shutdown: %w", plan.Name, closeErr)}
 		}
 	}
-	return suiteResult{pass: suitePass, fail: suiteFail}
+	return groupResult{pass: groupPass, fail: groupFail}
 }
 
 func emitFixtureStart(rep report.Reporter, plan discovery.Plan) time.Time {
@@ -698,7 +698,7 @@ func emitFixtureStart(rep report.Reporter, plan discovery.Plan) time.Time {
 	if plan.Fixture.Kind() != "" && plan.Fixture.Kind() != "remote" {
 		rep.Emit(report.Event{
 			Type:        report.EventFixtureStart,
-			Suite:       plan.Name,
+			Group:       plan.Name,
 			FixtureType: plan.Fixture.Kind(),
 			Ts:          start,
 		})
@@ -710,7 +710,7 @@ func emitFixtureReady(rep report.Reporter, plan discovery.Plan, start time.Time)
 	if plan.Fixture.Kind() != "" && plan.Fixture.Kind() != "remote" {
 		rep.Emit(report.Event{
 			Type:        report.EventFixtureReady,
-			Suite:       plan.Name,
+			Group:       plan.Name,
 			FixtureType: plan.Fixture.Kind(),
 			DurationMs:  time.Since(start).Milliseconds(),
 		})
@@ -725,7 +725,7 @@ func closeFixture(rep report.Reporter, plan discovery.Plan, fix fixture.Handle) 
 	if plan.Fixture.Kind() != "" && plan.Fixture.Kind() != "remote" {
 		rep.Emit(report.Event{
 			Type:        report.EventFixtureTeardown,
-			Suite:       plan.Name,
+			Group:       plan.Name,
 			FixtureType: plan.Fixture.Kind(),
 			DurationMs:  time.Since(start).Milliseconds(),
 		})

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -262,7 +262,7 @@ func ConvertDefinition(def model.TestCaseDefinition, name string) (*casefile.Cas
 }
 
 // fixtureFor builds the case-local fixture: block from a legacy definition. A
-// single-matrix override (selectedMatrix) takes precedence over the suite-level
+// single-matrix override (selectedMatrix) takes precedence over the config-level
 // blocks. Returns nil when the legacy definition declares no fixture.
 func fixtureFor(def model.TestCaseDefinition, selectedMatrix *model.Matrix) *casefile.FixtureConfig {
 	dc := def.DockerCompose

--- a/mise.toml
+++ b/mise.toml
@@ -40,7 +40,7 @@ description = "Run tests"
 run = 'GOFLAGS=-buildvcs=false go test $(GOFLAGS=-buildvcs=false go list ./... | grep -v "github.com/grafana/oats/tests/e2e")'
 
 [tasks.e2e-test]
-description = "Run e2e case suite"
+description = "Run e2e cases"
 run = "go test -v -buildvcs=false ./tests/e2e -run TestCases"
 
 [tasks.example-test]

--- a/report/event.go
+++ b/report/event.go
@@ -20,8 +20,8 @@ type EventType string
 const (
 	EventRunStart        EventType = "run.start"
 	EventRunEnd          EventType = "run.end"
-	EventSuiteStart      EventType = "suite.start"
-	EventSuiteEnd        EventType = "suite.end"
+	EventGroupStart      EventType = "group.start"
+	EventGroupEnd        EventType = "group.end"
 	EventFixtureStart    EventType = "fixture.start"
 	EventFixtureReady    EventType = "fixture.ready"
 	EventFixtureTeardown EventType = "fixture.teardown"
@@ -36,7 +36,7 @@ const (
 // SchemaVersion travels with each run.start event. Consumers pin to a
 // version; we bump on any breaking change (key removed, key semantics
 // changed). Additive changes are not breaking.
-const SchemaVersion = 1
+const SchemaVersion = 2
 
 // Event is the single payload type that crosses the Reporter boundary.
 // Fields are sparse on purpose — each event type populates only what it
@@ -54,13 +54,13 @@ type Event struct {
 	SchemaVersion int    `json:"schema_version,omitempty"`
 
 	// Identifying context.
-	Suite       string `json:"suite,omitempty"`
+	Group       string `json:"group,omitempty"`
 	FixtureType string `json:"fixture_type,omitempty"`
 	Case        string `json:"case,omitempty"`
 	Source      string `json:"source,omitempty"`
 
 	// Per-assertion / per-failure detail.
-	Msg           string `json:"msg,omitempty"`
+	Message       string `json:"msg,omitempty"`
 	Cmd           string `json:"cmd,omitempty"`
 	StdoutExcerpt string `json:"stdout_excerpt,omitempty"`
 

--- a/report/report_test.go
+++ b/report/report_test.go
@@ -31,11 +31,11 @@ func TestTextReporter_FailureBlockHasSourceAndCmd(t *testing.T) {
 	r.Emit(Event{Type: EventRunStart})
 	r.Emit(Event{Type: EventCaseStart, Case: "rolldice", Source: "examples/nodejs/oats.yaml:1"})
 	r.Emit(Event{
-		Type:   EventAssertFail,
-		Case:   "rolldice",
-		Source: "examples/nodejs/oats.yaml:8",
-		Msg:    "TraceQL returned no results",
-		Cmd:    "gcx traces search '{ span.http.route = \"/rolldice\" }'",
+		Type:    EventAssertFail,
+		Case:    "rolldice",
+		Source:  "examples/nodejs/oats.yaml:8",
+		Message: "TraceQL returned no results",
+		Cmd:     "gcx traces search '{ span.http.route = \"/rolldice\" }'",
 	})
 	r.Emit(Event{Type: EventCaseFail, Case: "rolldice"})
 	r.Emit(Event{Type: EventRunEnd})
@@ -62,17 +62,17 @@ func TestTextReporter_GHAAnnotationsWhenEnabled(t *testing.T) {
 	r := NewTextReporter(&buf, VerboseDefault)
 	r.Emit(Event{Type: EventRunStart})
 	r.Emit(Event{
-		Type:   EventAssertFail,
-		Case:   "x",
-		Source: "examples/nodejs/oats.yaml:8",
-		Msg:    "oops",
+		Type:    EventAssertFail,
+		Case:    "x",
+		Source:  "examples/nodejs/oats.yaml:8",
+		Message: "oops",
 	})
 	// Same source twice — only one annotation should appear.
 	r.Emit(Event{
-		Type:   EventAssertFail,
-		Case:   "x",
-		Source: "examples/nodejs/oats.yaml:8",
-		Msg:    "again",
+		Type:    EventAssertFail,
+		Case:    "x",
+		Source:  "examples/nodejs/oats.yaml:8",
+		Message: "again",
 	})
 	r.Emit(Event{Type: EventCaseFail, Case: "x"})
 	r.Emit(Event{Type: EventRunEnd})
@@ -94,9 +94,9 @@ func TestTextReporter_GHAAnnotationsWithoutSource(t *testing.T) {
 	r := NewTextReporter(&buf, VerboseDefault)
 	r.Emit(Event{Type: EventRunStart})
 	r.Emit(Event{
-		Type: EventAssertFail,
-		Case: "x",
-		Msg:  "oops",
+		Type:    EventAssertFail,
+		Case:    "x",
+		Message: "oops",
 	})
 	r.Emit(Event{Type: EventCaseFail, Case: "x"})
 	r.Emit(Event{Type: EventRunEnd})
@@ -117,10 +117,10 @@ func TestTextReporter_GHAAnnotationEscaping(t *testing.T) {
 	r := NewTextReporter(&buf, VerboseDefault)
 	r.Emit(Event{Type: EventRunStart})
 	r.Emit(Event{
-		Type:   EventAssertFail,
-		Case:   "x",
-		Source: "path/with,comma:x/a.yaml:8",
-		Msg:    "line one\nline two 50% off",
+		Type:    EventAssertFail,
+		Case:    "x",
+		Source:  "path/with,comma:x/a.yaml:8",
+		Message: "line one\nline two 50% off",
 	})
 	r.Emit(Event{Type: EventCaseFail, Case: "x"})
 	r.Emit(Event{Type: EventRunEnd})
@@ -170,7 +170,7 @@ func TestTextReporter_VerboseAllPrintsFixtureLifecycle(t *testing.T) {
 func TestNDJSONReporter_EmitsOneJSONObjectPerLine(t *testing.T) {
 	var buf bytes.Buffer
 	r := NewNDJSONReporter(&buf, VerboseDefault)
-	r.Emit(Event{Type: EventRunStart, OatsVersion: "x", SchemaVersion: 1, Ts: time.Now()})
+	r.Emit(Event{Type: EventRunStart, OatsVersion: "x", SchemaVersion: SchemaVersion, Ts: time.Now()})
 	r.Emit(Event{Type: EventCaseFail, Case: "rolldice", DurationMs: 1234})
 	r.Emit(Event{Type: EventRunEnd, Pass: 0, Fail: 1})
 
@@ -183,6 +183,27 @@ func TestNDJSONReporter_EmitsOneJSONObjectPerLine(t *testing.T) {
 		if err := json.Unmarshal([]byte(line), &e); err != nil {
 			t.Errorf("invalid JSON line %q: %v", line, err)
 		}
+	}
+}
+
+func TestNDJSONReporter_UsesFixtureGroupWireVocabulary(t *testing.T) {
+	var buf bytes.Buffer
+	r := NewNDJSONReporter(&buf, VerboseDefault)
+	r.Emit(Event{
+		Type:    EventGroupStart,
+		Group:   "smoke",
+		Message: "group is ready",
+	})
+
+	var event map[string]any
+	if err := json.Unmarshal(buf.Bytes(), &event); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+	if event["event"] != "group.start" || event["group"] != "smoke" {
+		t.Fatalf("unexpected group event: %#v", event)
+	}
+	if event["msg"] != "group is ready" {
+		t.Fatalf("message must retain the msg wire key: %#v", event)
 	}
 }
 

--- a/report/text.go
+++ b/report/text.go
@@ -95,8 +95,8 @@ func (r *TextReporter) recordFailure(e Event) {
 		src = "(unknown source)"
 	}
 	fmt.Fprintf(&b, "FAIL %s  %s\n", e.Case, src)
-	if e.Msg != "" {
-		fmt.Fprintf(&b, "  %s\n", e.Msg)
+	if e.Message != "" {
+		fmt.Fprintf(&b, "  %s\n", e.Message)
 	}
 	if e.Cmd != "" {
 		fmt.Fprintf(&b, "  $ %s\n", e.Cmd)
@@ -119,7 +119,7 @@ func (r *TextReporter) emitGHAAnnotation(e Event) {
 		}
 		r.knownErrAt[key] = struct{}{}
 
-		msg := e.Msg
+		msg := e.Message
 		if msg == "" {
 			msg = "OATS assertion failed"
 		}
@@ -136,7 +136,7 @@ func (r *TextReporter) emitGHAAnnotation(e Event) {
 	}
 	r.knownErrAt[key] = struct{}{}
 
-	msg := e.Msg
+	msg := e.Message
 	if msg == "" {
 		msg = "OATS assertion failed"
 	}

--- a/runner/assertions.go
+++ b/runner/assertions.go
@@ -56,11 +56,11 @@ func (r *Runner) runTraceStructured(ctx context.Context, c *casefile.Case, a *ca
 	cmdStr := signalcmd.Render(signalcmd.Traces(*a, 0))
 	for _, f := range result.LastFailures {
 		r.reporter.Emit(report.Event{
-			Type:   report.EventAssertFail,
-			Case:   c.Name,
-			Source: c.SourcePath,
-			Msg:    f.Error(),
-			Cmd:    cmdStr,
+			Type:    report.EventAssertFail,
+			Case:    c.Name,
+			Source:  c.SourcePath,
+			Message: f.Error(),
+			Cmd:     cmdStr,
 		})
 	}
 	return false

--- a/runner/checks.go
+++ b/runner/checks.go
@@ -38,11 +38,11 @@ func (r *Runner) runComposeLogCheck(ctx context.Context, c *casefile.Case, msg s
 	}
 	for _, f := range result.LastFailures {
 		r.reporter.Emit(report.Event{
-			Type:   report.EventAssertFail,
-			Case:   c.Name,
-			Source: c.SourcePath,
-			Msg:    f.Error(),
-			Cmd:    "compose-logs",
+			Type:    report.EventAssertFail,
+			Case:    c.Name,
+			Source:  c.SourcePath,
+			Message: f.Error(),
+			Cmd:     "compose-logs",
 		})
 	}
 	return false
@@ -81,11 +81,11 @@ func (r *Runner) runCustomCheck(ctx context.Context, c *casefile.Case, chk *case
 	}
 	for _, f := range result.LastFailures {
 		r.reporter.Emit(report.Event{
-			Type:   report.EventAssertFail,
-			Case:   c.Name,
-			Source: c.SourcePath,
-			Msg:    f.Error(),
-			Cmd:    "custom-check",
+			Type:    report.EventAssertFail,
+			Case:    c.Name,
+			Source:  c.SourcePath,
+			Message: f.Error(),
+			Cmd:     "custom-check",
 		})
 	}
 	return false

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -187,10 +187,10 @@ func (r *Runner) RunCase(ctx context.Context, c *casefile.Case) bool {
 		key := r.cacheKey(c)
 		if hit, _ := r.cacheStore.Lookup(key); hit {
 			r.reporter.Emit(report.Event{
-				Type:   report.EventCaseSkip,
-				Case:   c.Name,
-				Source: c.SourcePath,
-				Msg:    "cache hit (last green run within TTL)",
+				Type:    report.EventCaseSkip,
+				Case:    c.Name,
+				Source:  c.SourcePath,
+				Message: "cache hit (last green run within TTL)",
 			})
 			return true
 		}
@@ -378,21 +378,21 @@ func (r *Runner) pollAssert(
 	}
 	if len(result.LastFailures) == 0 {
 		r.reporter.Emit(report.Event{
-			Type:   report.EventAssertFail,
-			Case:   c.Name,
-			Source: c.SourcePath,
-			Msg:    "assertion polling stopped before any failure details were captured",
-			Cmd:    cmdStr,
+			Type:    report.EventAssertFail,
+			Case:    c.Name,
+			Source:  c.SourcePath,
+			Message: "assertion polling stopped before any failure details were captured",
+			Cmd:     cmdStr,
 		})
 		return false
 	}
 	for _, f := range result.LastFailures {
 		r.reporter.Emit(report.Event{
-			Type:   report.EventAssertFail,
-			Case:   c.Name,
-			Source: c.SourcePath,
-			Msg:    f.Error(),
-			Cmd:    cmdStr,
+			Type:    report.EventAssertFail,
+			Case:    c.Name,
+			Source:  c.SourcePath,
+			Message: f.Error(),
+			Cmd:     cmdStr,
 		})
 	}
 	return false
@@ -407,11 +407,11 @@ func (r *Runner) caseInterval(c *casefile.Case) time.Duration {
 
 func (r *Runner) failCase(c *casefile.Case, msg, cmd string) {
 	r.reporter.Emit(report.Event{
-		Type:   report.EventAssertFail,
-		Case:   c.Name,
-		Source: c.SourcePath,
-		Msg:    msg,
-		Cmd:    cmd,
+		Type:    report.EventAssertFail,
+		Case:    c.Name,
+		Source:  c.SourcePath,
+		Message: msg,
+		Cmd:     cmd,
 	})
 }
 

--- a/testhelpers/compose/compose.go
+++ b/testhelpers/compose/compose.go
@@ -1,4 +1,4 @@
-// Package docker provides some helpers to manage docker-compose clusters from the test suites
+// Package compose provides helpers to manage Docker Compose stacks used by fixture groups.
 package compose
 
 import (
@@ -52,11 +52,11 @@ func mergeEnv(parent, override []string) []string {
 	return merged
 }
 
-func Suite(composeFile string) (*Compose, error) {
-	return SuiteFiles([]string{composeFile}, nil)
+func Stack(composeFile string) (*Compose, error) {
+	return StackFiles([]string{composeFile}, nil)
 }
 
-func SuiteFiles(composeFiles []string, env []string) (*Compose, error) {
+func StackFiles(composeFiles []string, env []string) (*Compose, error) {
 	defaultArgs := []string{"compose"}
 	for _, file := range composeFiles {
 		defaultArgs = append(defaultArgs, "-f", file)
@@ -207,7 +207,7 @@ func NewEndpoint(host string, composeFilePath string, ports remote.PortsConfig) 
 			return fmt.Errorf("composeFilePath cannot be empty")
 		}
 
-		compose, err = Suite(composeFilePath)
+		compose, err = Stack(composeFilePath)
 		if err != nil {
 			return err
 		}

--- a/testhelpers/kubernetes/kubernetes_test.go
+++ b/testhelpers/kubernetes/kubernetes_test.go
@@ -11,7 +11,7 @@ import (
 )
 
 func TestClusterName_TruncatesFromEnd(t *testing.T) {
-	in := "this-is-a-very-long-suite-name-that-exceeds-thirty-two-chars"
+	in := "this-is-a-very-long-group-name-that-exceeds-thirty-two-chars"
 	got := clusterName(in)
 	if len(got) != 32 {
 		t.Fatalf("cluster length = %d, want 32 (%q)", len(got), got)
@@ -58,7 +58,7 @@ func TestStart_DefaultDockerContextAndCommandSequence(t *testing.T) {
 		return nil
 	}
 
-	if err := start(model, ports, "smoke-suite", run); err != nil {
+	if err := start(model, ports, "smoke-group", run); err != nil {
 		t.Fatalf("start: %v", err)
 	}
 	if model.AppDockerContext != "." {
@@ -67,11 +67,11 @@ func TestStart_DefaultDockerContextAndCommandSequence(t *testing.T) {
 
 	want := []string{
 		"fg: docker build -f Dockerfile -t dice:test .",
-		"fg: k3d cluster list smoke-suite",
-		"fg: k3d cluster delete smoke-suite",
-		"fg: k3d cluster create smoke-suite",
-		"fg: k3d image import -c smoke-suite dice:test",
-		"fg: k3d image import -c smoke-suite busybox:latest",
+		"fg: k3d cluster list smoke-group",
+		"fg: k3d cluster delete smoke-group",
+		"fg: k3d cluster create smoke-group",
+		"fg: k3d image import -c smoke-group dice:test",
+		"fg: k3d image import -c smoke-group busybox:latest",
 		"fg: kubectl apply -f k8s",
 		"fg: kubectl wait --timeout=5m --for=condition=available deployment/lgtm",
 		"bg: kubectl port-forward service/dice 18080:8080",

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -11,7 +11,7 @@ tests/e2e/cases/<group>/<case>/
 
 ## Defaults
 
-- `files/oats-config.yaml` is the default OATS config (suite/case list).
+- `files/oats-config.yaml` is the default OATS config (fixture-group/case list).
 - When `files/oats-config.yaml` is absent, the test runner synthesizes one that points
   at `files/oats-case.yaml`.
 - The harness boots a shared local LGTM stack plus real `oats` and real `gcx`.

--- a/tests/e2e/cases/cli/cache-skip/test.yaml
+++ b/tests/e2e/cases/cli/cache-skip/test.yaml
@@ -1,7 +1,7 @@
 name: cache-skip
 tags: [cli, cache]
 
-# Run the same suite twice against one cache dir; the second run must skip the
+# Run the same fixture group twice against one cache dir; the second run must skip the
 # unchanged case instead of re-running it. -v surfaces the SKIP line.
 run:
   shell: |

--- a/tests/e2e/cases/fixture/k3d-fail/test.yaml
+++ b/tests/e2e/cases/fixture/k3d-fail/test.yaml
@@ -8,4 +8,4 @@ expect:
   exit_code: 2
   stderr_contains:
     - 'error when creating "k8s/invalid.yaml"'
-    - 'suite "k3d-fail": exit status 1'
+    - 'fixture group "k3d-fail": exit status 1'


### PR DESCRIPTION
## Summary

- rename report lifecycle events and context from `suite` to `group`
- rename the Go `Event.Msg` field to `Message` while retaining the `msg` JSON key
- bump the report schema version for the wire-format change
- align fixture, compose, migration, examples, e2e, and CLI terminology with derived fixture groups

The v3 format already derives fixture-boot groups from case fixtures; the old suite vocabulary was stale and made the report contract misleading. This is intentionally based directly on `v2-integration` so the remaining follow-ups can target the same integration branch.

## Validation

- `GOFLAGS=-buildvcs=false go test ./...`
- `mise run lint`
