### PR TITLE
fix(cli): expose remote Grafana URL to checks

### DIFF
--- a/docs/case-reference.md
+++ b/docs/case-reference.md
@@ -295,14 +295,14 @@ assuming `/bin/sh` exists. The process runs with its working directory set to
 the case directory and inherits the parent environment plus these OATS-provided
 variables:
 
-| Variable                                                         | Fixtures     | Meaning                                              |
-| ---------------------------------------------------------------- | ------------ | ---------------------------------------------------- |
-| `OATS_FIXTURE_TYPE`                                              | all          | `remote` / `compose` / `k3d`                         |
-| `OATS_GRAFANA_URL`                                               | all          | base URL of the fixture's Grafana                    |
-| `OATS_APP_URL`                                                   | remote, k3d  | base URL of the app under test                       |
-| `OATS_OTLP_HTTP`                                                 | compose, k3d | OTLP/HTTP endpoint                                   |
-| `OATS_PYROSCOPE_URL`                                             | compose, k3d | Pyroscope base URL                                   |
-| `COMPOSE_PROJECT_NAME`, `COMPOSE_FILE`, `OATS_COMPOSE_FILE_ARGS` | compose      | let the script run its own `docker compose` commands |
+| Variable                                                         | Fixtures     | Meaning                                                                             |
+| ---------------------------------------------------------------- | ------------ | ----------------------------------------------------------------------------------- |
+| `OATS_FIXTURE_TYPE`                                              | all          | `remote` / `compose` / `k3d`                                                        |
+| `OATS_GRAFANA_URL`                                               | all          | base URL of the fixture's Grafana (remote: selected gcx context's `grafana.server`) |
+| `OATS_APP_URL`                                                   | remote, k3d  | base URL of the app under test                                                      |
+| `OATS_OTLP_HTTP`                                                 | compose, k3d | OTLP/HTTP endpoint                                                                  |
+| `OATS_PYROSCOPE_URL`                                             | compose, k3d | Pyroscope base URL                                                                  |
+| `COMPOSE_PROJECT_NAME`, `COMPOSE_FILE`, `OATS_COMPOSE_FILE_ARGS` | compose      | let the script run its own `docker compose` commands                                |
 
 A custom check that queries Grafana directly (replacing, for example, a legacy
 `compose-logs` grep with a real LogQL query):

--- a/internal/cli/gcx_config.go
+++ b/internal/cli/gcx_config.go
@@ -1,0 +1,155 @@
+package cli
+
+import (
+	"fmt"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"go.yaml.in/yaml/v3"
+)
+
+// The remote fixture is configured in gcx, not in the OATS case. Keep the
+// small subset needed for custom-check environment setup local to the CLI
+// rather than coupling OATS to gcx's internal config package.
+type gcxConfig struct {
+	CurrentContext string                `yaml:"current-context"`
+	Contexts       map[string]gcxContext `yaml:"contexts"`
+}
+
+type gcxContext struct {
+	Grafana *gcxGrafana `yaml:"grafana"`
+}
+
+type gcxGrafana struct {
+	Server string `yaml:"server"`
+}
+
+// remoteGrafanaURL reads the selected gcx context's Grafana server. An empty
+// result means no gcx config was discoverable; this keeps remote runs that do
+// not use custom checks compatible while avoiding the old, incorrect localhost
+// fallback. An explicitly supplied GCX_CONFIG is strict so malformed CI
+// configuration fails with an actionable error.
+func remoteGrafanaURL(contextName string) (string, error) {
+	paths, explicit := gcxConfigPaths()
+	if len(paths) == 0 {
+		return "", nil
+	}
+
+	merged := gcxConfig{Contexts: make(map[string]gcxContext)}
+	for _, path := range paths {
+		data, err := os.ReadFile(path)
+		if err != nil {
+			if explicit {
+				return "", fmt.Errorf("read gcx config %s: %w", path, err)
+			}
+			continue
+		}
+		var cfg gcxConfig
+		if err := yaml.Unmarshal(data, &cfg); err != nil {
+			if explicit {
+				return "", fmt.Errorf("parse gcx config %s: %w", path, err)
+			}
+			continue
+		}
+		if cfg.CurrentContext != "" {
+			merged.CurrentContext = cfg.CurrentContext
+		}
+		for name, context := range cfg.Contexts {
+			current := merged.Contexts[name]
+			if context.Grafana != nil && context.Grafana.Server != "" {
+				if current.Grafana == nil {
+					current.Grafana = &gcxGrafana{}
+				}
+				current.Grafana.Server = context.Grafana.Server
+			}
+			merged.Contexts[name] = current
+		}
+	}
+
+	if contextName == "" {
+		contextName = merged.CurrentContext
+	}
+	context, ok := merged.Contexts[contextName]
+	if !ok || context.Grafana == nil || strings.TrimSpace(context.Grafana.Server) == "" {
+		if explicit {
+			return "", fmt.Errorf("gcx context %q has no grafana.server", contextName)
+		}
+		return "", nil
+	}
+
+	server := strings.TrimRight(strings.TrimSpace(context.Grafana.Server), "/")
+	u, err := url.Parse(server)
+	if err != nil || u.Scheme == "" || u.Host == "" {
+		return "", fmt.Errorf("gcx context %q has invalid grafana.server %q", contextName, server)
+	}
+	return server, nil
+}
+
+// gcxConfigPaths mirrors gcx's useful config locations: an explicit
+// GCX_CONFIG, system config, the preferred user config, and a local .gcx.yaml.
+// The returned order is low-to-high priority so later files can overlay a
+// context's server value, matching gcx's layered configuration model.
+func gcxConfigPaths() ([]string, bool) {
+	if path := strings.TrimSpace(os.Getenv("GCX_CONFIG")); path != "" {
+		return []string{path}, true
+	}
+
+	var paths []string
+	for _, dir := range filepath.SplitList(configDirs()) {
+		if dir != "" {
+			paths = append(paths, filepath.Join(dir, "gcx", "config.yaml"))
+		}
+	}
+
+	homeConfig := ""
+	if home, err := os.UserHomeDir(); err == nil {
+		homeConfig = filepath.Join(home, ".config", "gcx", "config.yaml")
+	}
+	xdgConfig := ""
+	if dir := os.Getenv("XDG_CONFIG_HOME"); dir != "" {
+		xdgConfig = filepath.Join(dir, "gcx", "config.yaml")
+	} else if homeConfig != "" {
+		xdgConfig = homeConfig
+	}
+	// gcx prefers $HOME/.config over XDG_CONFIG_HOME when both exist.
+	if homeConfig != "" && fileExists(homeConfig) {
+		paths = append(paths, homeConfig)
+	} else if xdgConfig != "" {
+		paths = append(paths, xdgConfig)
+	}
+
+	if cwd, err := os.Getwd(); err == nil {
+		paths = append(paths, filepath.Join(cwd, ".gcx.yaml"))
+	}
+
+	var existing []string
+	for _, path := range paths {
+		if fileExists(path) && !contains(existing, path) {
+			existing = append(existing, path)
+		}
+	}
+	return existing, false
+}
+
+func configDirs() string {
+	if dirs := strings.TrimSpace(os.Getenv("XDG_CONFIG_DIRS")); dirs != "" {
+		return dirs
+	}
+	return "/etc/xdg"
+}
+
+func fileExists(path string) bool {
+	info, err := os.Stat(path)
+	return err == nil && !info.IsDir()
+}
+
+func contains(values []string, want string) bool {
+	for _, value := range values {
+		if value == want {
+			return true
+		}
+	}
+	return false
+}

--- a/internal/cli/gcx_config_test.go
+++ b/internal/cli/gcx_config_test.go
@@ -1,0 +1,87 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRemoteGrafanaURLFromExplicitGCXConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gcx.yaml")
+	if err := os.WriteFile(path, []byte(`current-context: remote
+contexts:
+  remote:
+    grafana:
+      server: https://grafana.example.test/
+  other:
+    grafana:
+      server: http://other.example.test
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GCX_CONFIG", path)
+
+	got, err := remoteGrafanaURL("remote")
+	if err != nil {
+		t.Fatalf("remoteGrafanaURL: %v", err)
+	}
+	if got != "https://grafana.example.test" {
+		t.Fatalf("remoteGrafanaURL = %q, want trimmed server URL", got)
+	}
+
+	got, err = remoteGrafanaURL("other")
+	if err != nil {
+		t.Fatalf("remoteGrafanaURL other: %v", err)
+	}
+	if got != "http://other.example.test" {
+		t.Fatalf("remoteGrafanaURL other = %q", got)
+	}
+}
+
+func TestRemoteGrafanaURLUsesCurrentContext(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gcx.yaml")
+	if err := os.WriteFile(path, []byte(`current-context: local
+contexts:
+  local:
+    grafana:
+      server: http://127.0.0.1:3000
+`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GCX_CONFIG", path)
+
+	got, err := remoteGrafanaURL("")
+	if err != nil {
+		t.Fatalf("remoteGrafanaURL: %v", err)
+	}
+	if got != "http://127.0.0.1:3000" {
+		t.Fatalf("remoteGrafanaURL = %q", got)
+	}
+}
+
+func TestRemoteGrafanaURLRejectsMissingServerInExplicitConfig(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "gcx.yaml")
+	if err := os.WriteFile(path, []byte("contexts:\n  remote: {}\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("GCX_CONFIG", path)
+
+	if _, err := remoteGrafanaURL("remote"); err == nil {
+		t.Fatal("expected missing grafana.server error")
+	}
+}
+
+func TestRemoteGrafanaURLWithoutConfigIsOptional(t *testing.T) {
+	t.Setenv("GCX_CONFIG", "")
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(t.TempDir(), "xdg"))
+	t.Setenv("XDG_CONFIG_DIRS", t.TempDir())
+
+	got, err := remoteGrafanaURL("remote")
+	if err != nil {
+		t.Fatalf("remoteGrafanaURL without config: %v", err)
+	}
+	if got != "" {
+		t.Fatalf("remoteGrafanaURL without config = %q, want empty", got)
+	}
+}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -64,9 +64,9 @@ contexts:
 	t.Setenv("GCX_CONFIG", config)
 
 	ep, err := resolveEndpoint(discovery.Plan{
-		Name:    "remote",
+		Name:    "remote-basic",
 		Fixture: casefile.FixtureConfig{Remote: &casefile.RemoteFixture{Endpoint: "http://otlp.example.test:4318"}},
-	}, fixture.Runtime{}, "", "localhost", 8080, "")
+	}, fixture.Runtime{}, "remote", "localhost", 8080, "")
 	if err != nil {
 		t.Fatalf("resolveEndpoint: %v", err)
 	}

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strconv"
 	"strings"
 	"testing"
@@ -49,6 +50,31 @@ func TestResolveEndpoint_UsesRuntimeAppHostPort(t *testing.T) {
 	}
 	if ep.GCXContext != "" || ep.AppPort != 18080 {
 		t.Fatalf("unexpected endpoint: %+v", ep)
+	}
+}
+
+func TestResolveEndpoint_RemoteUsesGCXGrafanaURL(t *testing.T) {
+	config := filepath.Join(t.TempDir(), "gcx.yaml")
+	writeFile(t, filepath.Dir(config), filepath.Base(config), `current-context: remote
+contexts:
+  remote:
+    grafana:
+      server: http://grafana.example.test:3000/
+`)
+	t.Setenv("GCX_CONFIG", config)
+
+	ep, err := resolveEndpoint(discovery.Plan{
+		Name:    "remote",
+		Fixture: casefile.FixtureConfig{Remote: &casefile.RemoteFixture{Endpoint: "http://otlp.example.test:4318"}},
+	}, fixture.Runtime{}, "", "localhost", 8080, "")
+	if err != nil {
+		t.Fatalf("resolveEndpoint: %v", err)
+	}
+	if ep.GCXContext != "remote" || ep.OTLPHTTP != "http://otlp.example.test:4318" {
+		t.Fatalf("unexpected remote endpoint: %+v", ep)
+	}
+	if !slices.Contains(ep.CustomCheckEnv, "OATS_GRAFANA_URL=http://grafana.example.test:3000") {
+		t.Fatalf("remote custom-check env missing Grafana URL: %v", ep.CustomCheckEnv)
 	}
 }
 

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -455,6 +455,9 @@ func resolveEndpoint(plan discovery.Plan, rt fixture.Runtime, gcxContextOverride
 		// (e.g. `gcx login` already ran). We pass the suite name as a
 		// best-effort default; --gcx-context overrides.
 		ep.GCXContext = plan.Name
+		if gcxContextOverride != "" {
+			ep.GCXContext = gcxContextOverride
+		}
 		ep.OTLPHTTP = plan.Fixture.Remote.Endpoint
 		grafana, err := remoteGrafanaURL(ep.GCXContext)
 		if err != nil {

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -456,11 +456,15 @@ func resolveEndpoint(plan discovery.Plan, rt fixture.Runtime, gcxContextOverride
 		// best-effort default; --gcx-context overrides.
 		ep.GCXContext = plan.Name
 		ep.OTLPHTTP = plan.Fixture.Remote.Endpoint
-		ep.CustomCheckEnv = append(ep.CustomCheckEnv,
-			"OATS_FIXTURE_TYPE=remote",
-			"OATS_GRAFANA_URL="+grafanaURL(),
-			"OATS_APP_URL="+fmt.Sprintf("http://%s:%d", ep.AppHost, ep.AppPort),
-		)
+		grafana, err := remoteGrafanaURL(ep.GCXContext)
+		if err != nil {
+			return runner.Endpoint{}, fmt.Errorf("resolve remote Grafana URL: %w", err)
+		}
+		ep.CustomCheckEnv = append(ep.CustomCheckEnv, "OATS_FIXTURE_TYPE=remote")
+		if grafana != "" {
+			ep.CustomCheckEnv = append(ep.CustomCheckEnv, "OATS_GRAFANA_URL="+grafana)
+		}
+		ep.CustomCheckEnv = append(ep.CustomCheckEnv, "OATS_APP_URL="+fmt.Sprintf("http://%s:%d", ep.AppHost, ep.AppPort))
 	case "compose":
 		if rt.GCXConfig != "" {
 			ep.GCXConfig = rt.GCXConfig
@@ -731,10 +735,6 @@ func closeFixture(rep report.Reporter, plan discovery.Plan, fix fixture.Handle) 
 		})
 	}
 	return nil
-}
-
-func grafanaURL() string {
-	return fmt.Sprintf("http://%s:%d", testhelpers.LocalhostIPv4, testhelpers.GrafanaHTTPPort)
 }
 
 func defaultOTLPHTTP() string {

--- a/tests/e2e/cases/custom/custom-check/files/verify.sh
+++ b/tests/e2e/cases/custom/custom-check/files/verify.sh
@@ -1,5 +1,4 @@
 #!/usr/bin/env bash
 set -euo pipefail
-grafana_url="$(awk '/server:/ {print $2; exit}' "${GCX_CONFIG:?}")"
-curl -fsS "${grafana_url}/api/health" >/dev/null
+curl -fsS "${OATS_GRAFANA_URL:?}/api/health" >/dev/null
 echo "custom check ok"


### PR DESCRIPTION
## Summary

- resolve `OATS_GRAFANA_URL` for remote fixtures from the selected gcx context's `grafana.server`
- mirror gcx's explicit, user, system, and local config discovery with a small OATS-owned parser
- update the remote custom-check e2e case to consume `OATS_GRAFANA_URL`
- document the remote behavior and cover explicit, current-context, missing-config, and invalid-config paths

Remote fixtures previously received a hard-coded `http://localhost:3000`, which is wrong for any remote Grafana and made the documented custom-check variable unusable. When no gcx config is discoverable, OATS omits the variable rather than inventing a URL; an explicit `GCX_CONFIG` remains strict and reports malformed configuration.

## Validation

- `GOFLAGS=-buildvcs=false go test ./...`
- `mise run lint`
