### PR TITLE
fix(runner): identify inline seed traffic

### DIFF
--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -644,6 +644,7 @@ func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts
 
 	gcxExec := &engine.GCX{Binary: opts.gcxBin, Context: ep.GCXContext, Config: ep.GCXConfig, Env: ep.GCXEnv}
 	r := runner.New(gcxExec, rep, ep, runner.Options{
+		OatsVersion:     Version,
 		Timeout:         opts.timeout,
 		Interval:        opts.interval,
 		AbsentTimeout:   opts.absentTimeout,
@@ -658,7 +659,6 @@ func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts
 			fixtureBytes, _ := json.Marshal(plan.Fixture)
 			r = r.WithCache(store, runner.CacheContext{
 				GCXVersion:   gcxVersion(opts.gcxBin),
-				OatsVersion:  Version,
 				FixtureBytes: fixtureBytes,
 			})
 		}

--- a/runner/cache_integration_test.go
+++ b/runner/cache_integration_test.go
@@ -44,13 +44,14 @@ func TestCache_HitShortCircuits(t *testing.T) {
 	var buf bytes.Buffer
 	rep := report.NewTextReporter(&buf, report.VerbosePasses)
 	r := New(exec, rep, Endpoint{GCXContext: "test"}, Options{
+		OatsVersion:     "v2",
 		Timeout:         100 * time.Millisecond,
 		Interval:        5 * time.Millisecond,
 		SeedSettleDelay: time.Nanosecond,
 	})
 
 	store, _ := cache.New(t.TempDir(), 0, nil)
-	r = r.WithCache(store, CacheContext{GCXVersion: "v1", OatsVersion: "v2"})
+	r = r.WithCache(store, CacheContext{GCXVersion: "v1"})
 
 	// First run: cache miss → runs the case → records on pass.
 	rep.Emit(report.Event{Type: report.EventRunStart})
@@ -67,10 +68,11 @@ func TestCache_HitShortCircuits(t *testing.T) {
 	buf.Reset()
 	rep = report.NewTextReporter(&buf, report.VerbosePasses)
 	r2 := New(exec, rep, Endpoint{GCXContext: "test"}, Options{
+		OatsVersion:     "v2",
 		Timeout:         100 * time.Millisecond,
 		Interval:        5 * time.Millisecond,
 		SeedSettleDelay: time.Nanosecond,
-	}).WithCache(store, CacheContext{GCXVersion: "v1", OatsVersion: "v2"})
+	}).WithCache(store, CacheContext{GCXVersion: "v1"})
 
 	rep.Emit(report.Event{Type: report.EventRunStart})
 	if !r2.RunCase(context.Background(), c) {
@@ -110,10 +112,11 @@ func TestCache_FailingRunLeavesNoGreenRecord(t *testing.T) {
 	var buf bytes.Buffer
 	rep := report.NewTextReporter(&buf, report.VerboseDefault)
 	r := New(exec, rep, Endpoint{GCXContext: "test"}, Options{
+		OatsVersion:     "v2",
 		Timeout:         30 * time.Millisecond,
 		Interval:        5 * time.Millisecond,
 		SeedSettleDelay: time.Nanosecond,
-	}).WithCache(store, CacheContext{GCXVersion: "v1", OatsVersion: "v2"})
+	}).WithCache(store, CacheContext{GCXVersion: "v1"})
 
 	rep.Emit(report.Event{Type: report.EventRunStart})
 	// First, ensure cache hit short-circuits before our patched stdout matters.

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -63,6 +63,10 @@ type Endpoint struct {
 // Options configures the polling cadence and per-case deadline. Sensible
 // zero-value defaults apply.
 type Options struct {
+	// OatsVersion identifies the OATS binary in cache keys and inline-OTLP
+	// User-Agent headers. It is set by the CLI even when caching is disabled.
+	OatsVersion string
+
 	// Timeout caps how long the runner waits for any one assertion to pass.
 	// Default 30s.
 	Timeout time.Duration
@@ -117,7 +121,6 @@ type Runner struct {
 // per case is wasted work.
 type CacheContext struct {
 	GCXVersion   string
-	OatsVersion  string
 	FixtureBytes []byte
 	Extra        map[string]string
 }
@@ -126,12 +129,13 @@ type CacheContext struct {
 // rep is typically a report.TextReporter or NDJSONReporter; ep names the
 // gcx context and (optionally) the OTLP endpoint for inline seeding.
 func New(exec engine.Executor, rep report.Reporter, ep Endpoint, opts Options) *Runner {
+	opts = opts.withDefaults()
 	return &Runner{
 		exec:     exec,
 		reporter: rep,
 		endpoint: ep,
-		opts:     opts.withDefaults(),
-		seeder:   &seed.Sender{OTLPEndpoint: ep.OTLPHTTP},
+		opts:     opts,
+		seeder:   &seed.Sender{OTLPEndpoint: ep.OTLPHTTP, Version: opts.OatsVersion},
 	}
 }
 
@@ -160,7 +164,7 @@ func (r *Runner) cacheKey(c *casefile.Case) cache.Key {
 		CaseYAML:     yamlBytes,
 		FixtureBytes: r.cacheCtx.FixtureBytes,
 		GCXVersion:   r.cacheCtx.GCXVersion,
-		OatsVersion:  r.cacheCtx.OatsVersion,
+		OatsVersion:  r.opts.OatsVersion,
 		Extra:        r.cacheCtx.Extra,
 	}
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -49,6 +49,13 @@ func newRunner(t *testing.T, exec engine.Executor, opts Options) (*Runner, *byte
 	return New(exec, rep, Endpoint{GCXContext: "test"}, opts), &buf
 }
 
+func TestNew_PropagatesOatsVersionToSeeder(t *testing.T) {
+	r, _ := newRunner(t, &stubExec{}, Options{OatsVersion: "0.7.0"})
+	if got := r.seeder.Version; got != "0.7.0" {
+		t.Fatalf("seed version = %q, want 0.7.0", got)
+	}
+}
+
 func mustParse(t *testing.T, src string) *casefile.Case {
 	t.Helper()
 	c, err := casefile.Parse([]byte(src))


### PR DESCRIPTION
## Summary

- move the OATS version from cache-only context into `runner.Options`
- use that one value for both cache keys and inline-OTLP `User-Agent` headers
- pass `internal/cli.Version` unconditionally, even when caching is disabled
- add runner coverage for the propagation

This makes seed traffic consistently identifiable as `oats/<version>` and avoids coupling the metadata to whether the cache happens to be enabled.

## Validation

- `GOFLAGS=-buildvcs=false go test ./...`
- `mise run lint`
