### PR TITLE
fix(cli): enforce minimum gcx version

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,12 +64,14 @@ Without mise:
 - **go install** (oats from source) — `go install github.com/grafana/oats@latest`.
 
 `oats` drives assertions through `gcx`. Release and mise-built binaries contain
-the pinned gcx version and automatically download and cache that verified
-release when `gcx` is not on `PATH`. Use `--gcx-download never` (or
-`OATS_GCX_DOWNLOAD=never`) to disable this fallback; mise-managed environments
-default to disabled downloads when mise is detected, even outside a mise task.
-You can always select a specific release with
-`--gcx-version <version>` or a binary with `--gcx <path>`.
+the minimum compatible gcx version. They use `gcx` from `PATH` when it meets
+that minimum, and automatically download and cache the verified minimum release
+when gcx is missing, too old, or does not report a parsable version. Use
+`--gcx-download never` (or `OATS_GCX_DOWNLOAD=never`) to disable this fallback;
+in that mode an absent or too-old PATH binary is an error. Mise-managed
+environments default to disabled downloads when mise is detected, even outside
+a mise task. You can explicitly trust a binary with `--gcx <path>` or select an
+exact release with `--gcx-version <version>`.
 
 ## Getting started
 

--- a/docs/ci.md
+++ b/docs/ci.md
@@ -46,12 +46,14 @@ go install github.com/grafana/oats@latest
 ```
 
 `oats --gcx-version 0.4.3` can download and cache gcx itself for fixture-backed
-runs. Release and mise-built oats binaries also embed the repository's pinned
-gcx version and can download it automatically when the default `gcx` command is
-missing. Set `OATS_GCX_DOWNLOAD=never` in strict or air-gapped CI; mise-managed
-environments default to this policy even outside a mise task. Pinning gcx explicitly with mise or a
-release download remains useful when you want the tool installation visible in
-your repository.
+runs. Release and mise-built oats binaries also embed the repository's minimum
+gcx version. They use the default `gcx` command when it meets that minimum and
+can download the verified release when gcx is missing, too old, or unparsable.
+Set `OATS_GCX_DOWNLOAD=never` in strict or air-gapped CI; mise-managed
+environments default to this policy even outside a mise task, so a missing or
+too-old gcx fails instead of triggering a network request. Pinning gcx
+explicitly with mise or a release download remains useful when you want the
+tool installation visible in your repository.
 
 ## The workflow shape
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,35 +35,39 @@ replace hyphens with underscores, and prefix it with `OATS_`. Command-line
 flags take precedence over environment variables. For example,
 `--gcx /opt/tools/gcx` is equivalent to `OATS_GCX=/opt/tools/gcx`.
 
-Release and mise-built `oats` binaries contain the gcx version pinned by this
-repository. If the default `gcx` command is not on `PATH`, `oats` downloads and
-caches that verified release automatically. Set `--gcx-download never` (or
-`OATS_GCX_DOWNLOAD=never`) for air-gapped or strict CI environments. The
+Release and mise-built `oats` binaries contain the minimum gcx version pinned
+by this repository. If the default `gcx` command is missing, older than that
+minimum, or does not report a parsable version, `oats` downloads and caches
+that verified release when the fallback policy is `auto`. Set
+`--gcx-download never` (or `OATS_GCX_DOWNLOAD=never`) for air-gapped or strict
+CI environments; an absent or too-old PATH binary then causes an error. The
 default is `never` when mise is detected (mise on `PATH`, a mise environment
-variable, or an executable installed under mise), and `auto` otherwise.
+variable, or an executable installed under mise), and `auto` otherwise. An
+explicit `--gcx <path>` bypasses the minimum-version check, while
+`--gcx-version` downloads and uses exactly the requested release.
 
 Flags:
 
-| Flag                        | Environment variable              | Default                                                            | Meaning                                                                                |
-| --------------------------- | --------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------- |
-| `--config`                  | `OATS_CONFIG`                     | `oats-config.yaml`, searched from current working directory upward | config file to load                                                                    |
-| `--tags`                    | `OATS_TAGS`                       | all                                                                | comma-separated tags; a case runs if it matches any                                    |
-| `--parallel`                | `OATS_PARALLEL`                   | `1`                                                                | fixture groups to run concurrently when fixture isolation allows                       |
-| `--fail-fast`               | `OATS_FAIL_FAST`                  | `false`                                                            | stop scheduling further cases after the first failure                                  |
-| `--timeout`                 | `OATS_TIMEOUT`                    | `30s`                                                              | per-assertion timeout — each assertion is retried until it passes or this elapses      |
-| `--interval`                | `OATS_INTERVAL`                   | `500ms`                                                            | polling interval between assertion retries                                             |
-| `--absent-timeout`          | `OATS_ABSENT_TIMEOUT`             | `10s`                                                              | window an `absent` assertion must stay empty to pass                                   |
-| `--seed-settle`             | `OATS_SEED_SETTLE`                | `2s`                                                               | wait after seeding before the first assertion                                          |
-| `--no-cache`                | `OATS_NO_CACHE`                   | `false`                                                            | ignore the skip-when-unchanged cache for this run                                      |
-| `--cache-dir`               | `OATS_CACHE_DIR`                  | platform user cache/state directory + `/oats`                      | directory for the skip-when-unchanged cache                                            |
-| `--format`                  | `OATS_FORMAT`                     | `text`                                                             | output format: `text` or `ndjson`                                                      |
-| `--gcx`                     | `OATS_GCX`                        | `gcx`                                                              | path to the gcx binary (`PATH`-resolved if a bare name)                                |
-| `--gcx-version`             | `OATS_GCX_VERSION`                | —                                                                  | download and use this gcx release (for example, `0.4.3`)                               |
-| `--gcx-download`            | `OATS_GCX_DOWNLOAD`               | `auto` (`never` when mise is detected)                             | fallback policy when the default gcx command is missing: `auto` or `never`             |
-| `--gcx-context`             | `OATS_GCX_CONTEXT`                | derived                                                            | gcx context to query (otherwise derived from the fixture endpoint)                     |
-| `--app-host` / `--app-port` | `OATS_APP_HOST` / `OATS_APP_PORT` | `localhost` / `8080`                                               | where to drive `input` requests when a fixture doesn't resolve the app endpoint itself |
-| `--otlp-http`               | `OATS_OTLP_HTTP`                  | `http://localhost:4318`                                            | OTLP/HTTP base URL for the `inline-otlp` seed                                          |
-| `--verbose`                 | `OATS_VERBOSE`                    | `0`                                                                | increase verbosity (`1`–`3` are the useful levels)                                     |
+| Flag                        | Environment variable              | Default                                                            | Meaning                                                                                            |
+| --------------------------- | --------------------------------- | ------------------------------------------------------------------ | -------------------------------------------------------------------------------------------------- |
+| `--config`                  | `OATS_CONFIG`                     | `oats-config.yaml`, searched from current working directory upward | config file to load                                                                                |
+| `--tags`                    | `OATS_TAGS`                       | all                                                                | comma-separated tags; a case runs if it matches any                                                |
+| `--parallel`                | `OATS_PARALLEL`                   | `1`                                                                | fixture groups to run concurrently when fixture isolation allows                                   |
+| `--fail-fast`               | `OATS_FAIL_FAST`                  | `false`                                                            | stop scheduling further cases after the first failure                                              |
+| `--timeout`                 | `OATS_TIMEOUT`                    | `30s`                                                              | per-assertion timeout — each assertion is retried until it passes or this elapses                  |
+| `--interval`                | `OATS_INTERVAL`                   | `500ms`                                                            | polling interval between assertion retries                                                         |
+| `--absent-timeout`          | `OATS_ABSENT_TIMEOUT`             | `10s`                                                              | window an `absent` assertion must stay empty to pass                                               |
+| `--seed-settle`             | `OATS_SEED_SETTLE`                | `2s`                                                               | wait after seeding before the first assertion                                                      |
+| `--no-cache`                | `OATS_NO_CACHE`                   | `false`                                                            | ignore the skip-when-unchanged cache for this run                                                  |
+| `--cache-dir`               | `OATS_CACHE_DIR`                  | platform user cache/state directory + `/oats`                      | directory for the skip-when-unchanged cache                                                        |
+| `--format`                  | `OATS_FORMAT`                     | `text`                                                             | output format: `text` or `ndjson`                                                                  |
+| `--gcx`                     | `OATS_GCX`                        | `gcx`                                                              | path to the gcx binary (`PATH`-resolved if a bare name)                                            |
+| `--gcx-version`             | `OATS_GCX_VERSION`                | —                                                                  | download and use this gcx release (for example, `0.4.3`)                                           |
+| `--gcx-download`            | `OATS_GCX_DOWNLOAD`               | `auto` (`never` when mise is detected)                             | fallback policy when the default gcx command is missing, too old, or unparsable: `auto` or `never` |
+| `--gcx-context`             | `OATS_GCX_CONTEXT`                | derived                                                            | gcx context to query (otherwise derived from the fixture endpoint)                                 |
+| `--app-host` / `--app-port` | `OATS_APP_HOST` / `OATS_APP_PORT` | `localhost` / `8080`                                               | where to drive `input` requests when a fixture doesn't resolve the app endpoint itself             |
+| `--otlp-http`               | `OATS_OTLP_HTTP`                  | `http://localhost:4318`                                            | OTLP/HTTP base URL for the `inline-otlp` seed                                                      |
+| `--verbose`                 | `OATS_VERBOSE`                    | `0`                                                                | increase verbosity (`1`–`3` are the useful levels)                                                 |
 
 The deprecated hidden aliases `--list` and `--migrate` also accept
 `OATS_LIST` and `OATS_MIGRATE`. `oats list --config` uses `OATS_CONFIG`, and

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/grafana/oats
 go 1.26.4
 
 require (
+	github.com/hashicorp/go-version v1.9.0
 	github.com/onsi/gomega v1.42.1
 	github.com/spf13/cobra v1.10.2
 	github.com/spf13/pflag v1.0.9
@@ -24,7 +25,6 @@ require (
 	github.com/google/go-cmp v0.7.0 // indirect
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/grpc-ecosystem/grpc-gateway/v2 v2.29.0 // indirect
-	github.com/hashicorp/go-version v1.9.0 // indirect
 	github.com/inconshreveable/mousetrap v1.1.0 // indirect
 	github.com/json-iterator/go v1.1.12 // indirect
 	github.com/modern-go/concurrent v0.0.0-20180306012644-bacd9c7ef1dd // indirect

--- a/internal/cli/env_flags_test.go
+++ b/internal/cli/env_flags_test.go
@@ -12,12 +12,12 @@ func TestApplyEnvFlags(t *testing.T) {
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
 	fs.Duration("timeout", 30*time.Second, "timeout")
 	fs.String("gcx", "gcx", "gcx binary")
-	fs.String("gcx-download", "auto", "gcx download policy")
+	fs.String("gcx-download", gcxDownloadPolicyAuto, "gcx download policy")
 	fs.Bool("no-cache", false, "disable cache")
 
 	t.Setenv("OATS_TIMEOUT", "2s")
 	t.Setenv("OATS_GCX", "/opt/tools/gcx")
-	t.Setenv("OATS_GCX_DOWNLOAD", "never")
+	t.Setenv("OATS_GCX_DOWNLOAD", gcxDownloadPolicyNever)
 	t.Setenv("OATS_NO_CACHE", "true")
 
 	if err := applyEnvFlags(fs); err != nil {
@@ -30,8 +30,8 @@ func TestApplyEnvFlags(t *testing.T) {
 	if got := flagStr(fs, "gcx"); got != "/opt/tools/gcx" {
 		t.Fatalf("gcx = %q, want /opt/tools/gcx", got)
 	}
-	if got := flagStr(fs, "gcx-download"); got != "never" {
-		t.Fatalf("gcx-download = %q, want never", got)
+	if got := flagStr(fs, "gcx-download"); got != gcxDownloadPolicyNever {
+		t.Fatalf("gcx-download = %q, want %s", got, gcxDownloadPolicyNever)
 	}
 	if !flagBool(fs, "no-cache") {
 		t.Fatal("no-cache = false, want true")

--- a/internal/cli/gcx_bootstrap.go
+++ b/internal/cli/gcx_bootstrap.go
@@ -15,10 +15,10 @@ import (
 	"path/filepath"
 	"regexp"
 	"runtime"
-	"strconv"
 	"strings"
 	"time"
 
+	hashicorpversion "github.com/hashicorp/go-version"
 	"github.com/spf13/pflag"
 )
 
@@ -26,14 +26,19 @@ var gcxReleaseBaseURL = "https://github.com/grafana/gcx/releases/download"
 
 var gcxHTTPClient = &http.Client{Timeout: 10 * time.Minute}
 
+const (
+	gcxDownloadPolicyAuto  = "auto"
+	gcxDownloadPolicyNever = "never"
+)
+
 func defaultGCXDownloadPolicy() string {
 	// A mise-managed environment is expected to install its declared tools and
 	// should not silently reach out to GitHub if that setup is incomplete. The
 	// OATS_GCX_DOWNLOAD/--gcx-download override remains available when desired.
 	if isMiseEnvironment() {
-		return "never"
+		return gcxDownloadPolicyNever
 	}
-	return "auto"
+	return gcxDownloadPolicyAuto
 }
 
 func isMiseEnvironment() bool {
@@ -66,8 +71,8 @@ func resolveDefaultGCX(fs *pflag.FlagSet, gcxBin string) (string, error) {
 		return "", err
 	}
 	policy = strings.ToLower(strings.TrimSpace(policy))
-	if policy != "auto" && policy != "never" {
-		return "", fmt.Errorf("invalid --gcx-download %q (want auto or never)", policy)
+	if policy != gcxDownloadPolicyAuto && policy != gcxDownloadPolicyNever {
+		return "", fmt.Errorf("invalid --gcx-download %q (want %s or %s)", policy, gcxDownloadPolicyAuto, gcxDownloadPolicyNever)
 	}
 
 	if _, err := exec.LookPath(gcxBin); err == nil {
@@ -82,7 +87,7 @@ func resolveDefaultGCX(fs *pflag.FlagSet, gcxBin string) (string, error) {
 		if gcxVersionAtLeast(installedVersion, MinimumGCXVersion) {
 			return gcxBin, nil
 		}
-		if policy == "never" {
+		if policy == gcxDownloadPolicyNever {
 			if installedVersion == "" {
 				return "", fmt.Errorf("gcx on PATH did not report a version (minimum %s; automatic download is disabled)", MinimumGCXVersion)
 			}
@@ -104,8 +109,8 @@ func resolveDefaultGCX(fs *pflag.FlagSet, gcxBin string) (string, error) {
 	if fs.Changed("gcx") {
 		return "", fmt.Errorf("gcx binary %q was not found (set --gcx to its path)", gcxBin)
 	}
-	if policy == "never" {
-		return "", fmt.Errorf("gcx was not found on PATH and automatic download is disabled (install gcx, set --gcx, or use --gcx-download auto)")
+	if policy == gcxDownloadPolicyNever {
+		return "", fmt.Errorf("gcx was not found on PATH and automatic download is disabled (install gcx, set --gcx, or use --gcx-download %s)", gcxDownloadPolicyAuto)
 	}
 	if MinimumGCXVersion == "" {
 		return "", fmt.Errorf("gcx was not found on PATH and this oats build has no embedded minimum gcx version (install gcx or pass --gcx-version)")
@@ -119,89 +124,28 @@ func resolveDefaultGCX(fs *pflag.FlagSet, gcxBin string) (string, error) {
 	return bootstrapGCX(MinimumGCXVersion, cacheDir)
 }
 
-var gcxVersionPattern = regexp.MustCompile(`(?:^|[^0-9])v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z.-]+))?`)
+var gcxVersionPattern = regexp.MustCompile(`(?:^|[^0-9A-Za-z])(v?[0-9]+\.[0-9]+\.[0-9]+(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?)`)
 
-type parsedGCXVersion struct {
-	major      int
-	minor      int
-	patch      int
-	prerelease string
-}
-
-func parseGCXVersion(value string) (parsedGCXVersion, bool) {
+func parseGCXVersion(value string) (string, bool) {
 	match := gcxVersionPattern.FindStringSubmatch(value)
 	if len(match) == 0 {
-		return parsedGCXVersion{}, false
+		return "", false
 	}
-	major, errMajor := strconv.Atoi(match[1])
-	minor, errMinor := strconv.Atoi(match[2])
-	patch, errPatch := strconv.Atoi(match[3])
-	if errMajor != nil || errMinor != nil || errPatch != nil {
-		return parsedGCXVersion{}, false
-	}
-	return parsedGCXVersion{
-		major:      major,
-		minor:      minor,
-		patch:      patch,
-		prerelease: match[4],
-	}, true
+	return strings.TrimPrefix(match[1], "v"), true
 }
 
 func gcxVersionAtLeast(installed, minimum string) bool {
-	got, gotOK := parseGCXVersion(installed)
-	want, wantOK := parseGCXVersion(minimum)
-	if !gotOK || !wantOK {
+	installedVersion, installedOK := parseGCXVersion(installed)
+	minimumVersion, minimumOK := parseGCXVersion(minimum)
+	if !installedOK || !minimumOK {
 		return false
 	}
-	if got.major != want.major {
-		return got.major > want.major
+	got, gotErr := hashicorpversion.NewSemver(installedVersion)
+	want, wantErr := hashicorpversion.NewSemver(minimumVersion)
+	if gotErr != nil || wantErr != nil {
+		return false
 	}
-	if got.minor != want.minor {
-		return got.minor > want.minor
-	}
-	if got.patch != want.patch {
-		return got.patch > want.patch
-	}
-	return compareGCXPrerelease(got.prerelease, want.prerelease) >= 0
-}
-
-func compareGCXPrerelease(a, b string) int {
-	if a == b {
-		return 0
-	}
-	if a == "" {
-		return 1
-	}
-	if b == "" {
-		return -1
-	}
-
-	aParts := strings.Split(a, ".")
-	bParts := strings.Split(b, ".")
-	for i := 0; i < len(aParts) && i < len(bParts); i++ {
-		aNumber, aErr := strconv.Atoi(aParts[i])
-		bNumber, bErr := strconv.Atoi(bParts[i])
-		switch {
-		case aErr == nil && bErr == nil && aNumber != bNumber:
-			if aNumber < bNumber {
-				return -1
-			}
-			return 1
-		case aErr == nil && bErr != nil:
-			return -1
-		case aErr != nil && bErr == nil:
-			return 1
-		case aParts[i] != bParts[i]:
-			if aParts[i] < bParts[i] {
-				return -1
-			}
-			return 1
-		}
-	}
-	if len(aParts) < len(bParts) {
-		return -1
-	}
-	return 1
+	return got.GreaterThanOrEqual(want)
 }
 
 // bootstrapGCX downloads a verified gcx release into the user's cache and

--- a/internal/cli/gcx_bootstrap.go
+++ b/internal/cli/gcx_bootstrap.go
@@ -13,7 +13,9 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"regexp"
 	"runtime"
+	"strconv"
 	"strings"
 	"time"
 
@@ -69,24 +71,137 @@ func resolveDefaultGCX(fs *pflag.FlagSet, gcxBin string) (string, error) {
 	}
 
 	if _, err := exec.LookPath(gcxBin); err == nil {
-		return gcxBin, nil
+		// An explicit --gcx is an intentional override, so do not second-guess
+		// its version. The embedded minimum protects only the implicit PATH lookup
+		// from accidentally selecting an older local installation.
+		if fs.Changed("gcx") || MinimumGCXVersion == "" {
+			return gcxBin, nil
+		}
+
+		installedVersion := gcxVersion(gcxBin)
+		if gcxVersionAtLeast(installedVersion, MinimumGCXVersion) {
+			return gcxBin, nil
+		}
+		if policy == "never" {
+			if installedVersion == "" {
+				return "", fmt.Errorf("gcx on PATH did not report a version (minimum %s; automatic download is disabled)", MinimumGCXVersion)
+			}
+			return "", fmt.Errorf("gcx on PATH is %s, but oats requires at least %s (automatic download is disabled; install a newer gcx or set --gcx to override)", installedVersion, MinimumGCXVersion)
+		}
+
+		if installedVersion == "" {
+			fmt.Fprintf(os.Stderr, "gcx on PATH did not report a parseable version; downloading minimum gcx %s\n", MinimumGCXVersion)
+		} else {
+			fmt.Fprintf(os.Stderr, "gcx on PATH is %s; downloading minimum gcx %s\n", installedVersion, MinimumGCXVersion)
+		}
+		cacheDir, err := fs.GetString("cache-dir")
+		if err != nil {
+			return "", err
+		}
+		return bootstrapGCX(MinimumGCXVersion, cacheDir)
 	}
+
 	if fs.Changed("gcx") {
 		return "", fmt.Errorf("gcx binary %q was not found (set --gcx to its path)", gcxBin)
 	}
 	if policy == "never" {
 		return "", fmt.Errorf("gcx was not found on PATH and automatic download is disabled (install gcx, set --gcx, or use --gcx-download auto)")
 	}
-	if DefaultGCXVersion == "" {
-		return "", fmt.Errorf("gcx was not found on PATH and this oats build has no embedded gcx version (install gcx or pass --gcx-version)")
+	if MinimumGCXVersion == "" {
+		return "", fmt.Errorf("gcx was not found on PATH and this oats build has no embedded minimum gcx version (install gcx or pass --gcx-version)")
 	}
 
-	fmt.Fprintf(os.Stderr, "gcx was not found on PATH; downloading pinned gcx %s\n", DefaultGCXVersion)
+	fmt.Fprintf(os.Stderr, "gcx was not found on PATH; downloading minimum gcx %s\n", MinimumGCXVersion)
 	cacheDir, err := fs.GetString("cache-dir")
 	if err != nil {
 		return "", err
 	}
-	return bootstrapGCX(DefaultGCXVersion, cacheDir)
+	return bootstrapGCX(MinimumGCXVersion, cacheDir)
+}
+
+var gcxVersionPattern = regexp.MustCompile(`(?:^|[^0-9])v?([0-9]+)\.([0-9]+)\.([0-9]+)(?:-([0-9A-Za-z.-]+))?`)
+
+type parsedGCXVersion struct {
+	major      int
+	minor      int
+	patch      int
+	prerelease string
+}
+
+func parseGCXVersion(value string) (parsedGCXVersion, bool) {
+	match := gcxVersionPattern.FindStringSubmatch(value)
+	if len(match) == 0 {
+		return parsedGCXVersion{}, false
+	}
+	major, errMajor := strconv.Atoi(match[1])
+	minor, errMinor := strconv.Atoi(match[2])
+	patch, errPatch := strconv.Atoi(match[3])
+	if errMajor != nil || errMinor != nil || errPatch != nil {
+		return parsedGCXVersion{}, false
+	}
+	return parsedGCXVersion{
+		major:      major,
+		minor:      minor,
+		patch:      patch,
+		prerelease: match[4],
+	}, true
+}
+
+func gcxVersionAtLeast(installed, minimum string) bool {
+	got, gotOK := parseGCXVersion(installed)
+	want, wantOK := parseGCXVersion(minimum)
+	if !gotOK || !wantOK {
+		return false
+	}
+	if got.major != want.major {
+		return got.major > want.major
+	}
+	if got.minor != want.minor {
+		return got.minor > want.minor
+	}
+	if got.patch != want.patch {
+		return got.patch > want.patch
+	}
+	return compareGCXPrerelease(got.prerelease, want.prerelease) >= 0
+}
+
+func compareGCXPrerelease(a, b string) int {
+	if a == b {
+		return 0
+	}
+	if a == "" {
+		return 1
+	}
+	if b == "" {
+		return -1
+	}
+
+	aParts := strings.Split(a, ".")
+	bParts := strings.Split(b, ".")
+	for i := 0; i < len(aParts) && i < len(bParts); i++ {
+		aNumber, aErr := strconv.Atoi(aParts[i])
+		bNumber, bErr := strconv.Atoi(bParts[i])
+		switch {
+		case aErr == nil && bErr == nil && aNumber != bNumber:
+			if aNumber < bNumber {
+				return -1
+			}
+			return 1
+		case aErr == nil && bErr != nil:
+			return -1
+		case aErr != nil && bErr == nil:
+			return 1
+		case aParts[i] != bParts[i]:
+			if aParts[i] < bParts[i] {
+				return -1
+			}
+			return 1
+		}
+	}
+	if len(aParts) < len(bParts) {
+		return -1
+	}
+	return 1
 }
 
 // bootstrapGCX downloads a verified gcx release into the user's cache and

--- a/internal/cli/gcx_bootstrap.go
+++ b/internal/cli/gcx_bootstrap.go
@@ -18,7 +18,7 @@ import (
 	"strings"
 	"time"
 
-	hashicorpversion "github.com/hashicorp/go-version"
+	semver "github.com/hashicorp/go-version"
 	"github.com/spf13/pflag"
 )
 
@@ -140,8 +140,8 @@ func gcxVersionAtLeast(installed, minimum string) bool {
 	if !installedOK || !minimumOK {
 		return false
 	}
-	got, gotErr := hashicorpversion.NewSemver(installedVersion)
-	want, wantErr := hashicorpversion.NewSemver(minimumVersion)
+	got, gotErr := semver.NewSemver(installedVersion)
+	want, wantErr := semver.NewSemver(minimumVersion)
 	if gotErr != nil || wantErr != nil {
 		return false
 	}

--- a/internal/cli/gcx_runtime_test.go
+++ b/internal/cli/gcx_runtime_test.go
@@ -57,9 +57,9 @@ func TestResolveDefaultGCXUsesEmbeddedVersion(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	oldVersion := DefaultGCXVersion
-	DefaultGCXVersion = "0.4.3"
-	t.Cleanup(func() { DefaultGCXVersion = oldVersion })
+	oldVersion := MinimumGCXVersion
+	MinimumGCXVersion = "0.4.3"
+	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
 
 	fs := gcxRuntimeFlags(cacheDir, "auto")
 	got, err := resolveDefaultGCX(fs, "oats-gcx-test-not-on-path")
@@ -79,9 +79,9 @@ func TestResolveDefaultGCXRejectsDisabledDownload(t *testing.T) {
 }
 
 func TestResolveDefaultGCXRequiresEmbeddedVersion(t *testing.T) {
-	oldVersion := DefaultGCXVersion
-	DefaultGCXVersion = ""
-	t.Cleanup(func() { DefaultGCXVersion = oldVersion })
+	oldVersion := MinimumGCXVersion
+	MinimumGCXVersion = ""
+	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
 
 	fs := gcxRuntimeFlags(t.TempDir(), "auto")
 	if _, err := resolveDefaultGCX(fs, "oats-gcx-test-not-on-path"); err == nil {
@@ -96,9 +96,120 @@ func TestResolveDefaultGCXRejectsInvalidPolicy(t *testing.T) {
 	}
 }
 
+func TestGCXVersionAtLeast(t *testing.T) {
+	tests := []struct {
+		installed string
+		minimum   string
+		want      bool
+	}{
+		{installed: "gcx version 0.4.4 built from abc", minimum: "0.4.3", want: true},
+		{installed: "v0.4.3", minimum: "0.4.3", want: true},
+		{installed: "gcx version 0.4.2", minimum: "0.4.3", want: false},
+		{installed: "gcx version 0.5.0", minimum: "0.4.3", want: true},
+		{installed: "gcx version 0.4.3-rc.1", minimum: "0.4.3", want: false},
+		{installed: "SNAPSHOT", minimum: "0.4.3", want: false},
+	}
+	for _, tt := range tests {
+		if got := gcxVersionAtLeast(tt.installed, tt.minimum); got != tt.want {
+			t.Errorf("gcxVersionAtLeast(%q, %q) = %v, want %v", tt.installed, tt.minimum, got, tt.want)
+		}
+	}
+}
+
+func TestResolveDefaultGCXUsesSufficientPathVersion(t *testing.T) {
+	oldVersion := MinimumGCXVersion
+	MinimumGCXVersion = "0.4.3"
+	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
+
+	gcxBin := fakeGCXOnPath(t, "0.4.3")
+	fs := gcxRuntimeFlags(t.TempDir(), "auto")
+	got, err := resolveDefaultGCX(fs, gcxBin)
+	if err != nil {
+		t.Fatalf("resolveDefaultGCX: %v", err)
+	}
+	if got != gcxBin {
+		t.Fatalf("resolveDefaultGCX = %q, want %q", got, gcxBin)
+	}
+}
+
+func TestResolveDefaultGCXFallsBackForOlderPathVersion(t *testing.T) {
+	cacheDir := t.TempDir()
+	target := filepath.Join(cacheDir, "tools", "gcx", "0.4.3", runtime.GOOS+"_"+runtime.GOARCH, "gcx")
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(target, []byte("cached gcx"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	oldVersion := MinimumGCXVersion
+	MinimumGCXVersion = "0.4.3"
+	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
+
+	gcxBin := fakeGCXOnPath(t, "0.4.2")
+	fs := gcxRuntimeFlags(cacheDir, "auto")
+	got, err := resolveDefaultGCX(fs, gcxBin)
+	if err != nil {
+		t.Fatalf("resolveDefaultGCX: %v", err)
+	}
+	if got != target {
+		t.Fatalf("resolveDefaultGCX = %q, want cached minimum %q", got, target)
+	}
+}
+
+func TestResolveDefaultGCXRejectsOlderPathVersionWhenDownloadsDisabled(t *testing.T) {
+	oldVersion := MinimumGCXVersion
+	MinimumGCXVersion = "0.4.3"
+	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
+
+	gcxBin := fakeGCXOnPath(t, "0.4.2")
+	fs := gcxRuntimeFlags(t.TempDir(), "never")
+	if _, err := resolveDefaultGCX(fs, gcxBin); err == nil {
+		t.Fatal("expected minimum version error")
+	}
+}
+
+func TestResolveDefaultGCXExplicitPathOverridesMinimum(t *testing.T) {
+	oldVersion := MinimumGCXVersion
+	MinimumGCXVersion = "0.4.3"
+	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
+
+	gcxBin := fakeGCXOnPath(t, "0.4.2")
+	fs := gcxRuntimeFlags(t.TempDir(), "never")
+	if err := fs.Set("gcx", gcxBin); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveDefaultGCX(fs, gcxBin)
+	if err != nil {
+		t.Fatalf("resolveDefaultGCX: %v", err)
+	}
+	if got != gcxBin {
+		t.Fatalf("resolveDefaultGCX = %q, want %q", got, gcxBin)
+	}
+}
+
 func gcxRuntimeFlags(cacheDir, downloadPolicy string) *pflag.FlagSet {
 	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("gcx", "gcx", "")
 	fs.String("gcx-download", downloadPolicy, "")
 	fs.String("cache-dir", cacheDir, "")
 	return fs
+}
+
+func fakeGCXOnPath(t *testing.T, version string) string {
+	t.Helper()
+	dir := t.TempDir()
+	name := "gcx"
+	contents := "#!/bin/sh\nprintf 'gcx version " + version + " built from test\\n'\n"
+	permissions := 0o755
+	if runtime.GOOS == "windows" {
+		name += ".cmd"
+		contents = "@echo off\r\necho gcx version " + version + " built from test\r\n"
+		permissions = 0o644
+	}
+	if err := os.WriteFile(filepath.Join(dir, name), []byte(contents), os.FileMode(permissions)); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+	return "gcx"
 }

--- a/internal/cli/gcx_runtime_test.go
+++ b/internal/cli/gcx_runtime_test.go
@@ -11,14 +11,14 @@ import (
 
 func TestDefaultGCXDownloadPolicy(t *testing.T) {
 	t.Setenv("MISE_CONFIG_ROOT", "/tmp/mise")
-	if got := defaultGCXDownloadPolicy(); got != "never" {
-		t.Fatalf("defaultGCXDownloadPolicy with mise = %q, want never", got)
+	if got := defaultGCXDownloadPolicy(); got != gcxDownloadPolicyNever {
+		t.Fatalf("defaultGCXDownloadPolicy with mise = %q, want %s", got, gcxDownloadPolicyNever)
 	}
 	t.Setenv("MISE_CONFIG_ROOT", "")
 	t.Setenv("MISE_PROJECT_ROOT", "")
 	t.Setenv("PATH", t.TempDir())
-	if got := defaultGCXDownloadPolicy(); got != "auto" {
-		t.Fatalf("defaultGCXDownloadPolicy without mise = %q, want auto", got)
+	if got := defaultGCXDownloadPolicy(); got != gcxDownloadPolicyAuto {
+		t.Fatalf("defaultGCXDownloadPolicy without mise = %q, want %s", got, gcxDownloadPolicyAuto)
 	}
 
 	miseDir := t.TempDir()
@@ -27,8 +27,8 @@ func TestDefaultGCXDownloadPolicy(t *testing.T) {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", miseDir)
-	if got := defaultGCXDownloadPolicy(); got != "never" {
-		t.Fatalf("defaultGCXDownloadPolicy with mise on PATH = %q, want never", got)
+	if got := defaultGCXDownloadPolicy(); got != gcxDownloadPolicyNever {
+		t.Fatalf("defaultGCXDownloadPolicy with mise on PATH = %q, want %s", got, gcxDownloadPolicyNever)
 	}
 }
 
@@ -61,7 +61,7 @@ func TestResolveDefaultGCXUsesEmbeddedVersion(t *testing.T) {
 	MinimumGCXVersion = "0.4.3"
 	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
 
-	fs := gcxRuntimeFlags(cacheDir, "auto")
+	fs := gcxRuntimeFlags(cacheDir, gcxDownloadPolicyAuto)
 	got, err := resolveDefaultGCX(fs, "oats-gcx-test-not-on-path")
 	if err != nil {
 		t.Fatalf("resolveDefaultGCX: %v", err)
@@ -72,7 +72,7 @@ func TestResolveDefaultGCXUsesEmbeddedVersion(t *testing.T) {
 }
 
 func TestResolveDefaultGCXRejectsDisabledDownload(t *testing.T) {
-	fs := gcxRuntimeFlags(t.TempDir(), "never")
+	fs := gcxRuntimeFlags(t.TempDir(), gcxDownloadPolicyNever)
 	if _, err := resolveDefaultGCX(fs, "oats-gcx-test-not-on-path"); err == nil {
 		t.Fatal("expected disabled download error")
 	}
@@ -83,7 +83,7 @@ func TestResolveDefaultGCXRequiresEmbeddedVersion(t *testing.T) {
 	MinimumGCXVersion = ""
 	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
 
-	fs := gcxRuntimeFlags(t.TempDir(), "auto")
+	fs := gcxRuntimeFlags(t.TempDir(), gcxDownloadPolicyAuto)
 	if _, err := resolveDefaultGCX(fs, "oats-gcx-test-not-on-path"); err == nil {
 		t.Fatal("expected missing embedded version error")
 	}
@@ -122,7 +122,7 @@ func TestResolveDefaultGCXUsesSufficientPathVersion(t *testing.T) {
 	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
 
 	gcxBin := fakeGCXOnPath(t, "0.4.3")
-	fs := gcxRuntimeFlags(t.TempDir(), "auto")
+	fs := gcxRuntimeFlags(t.TempDir(), gcxDownloadPolicyAuto)
 	got, err := resolveDefaultGCX(fs, gcxBin)
 	if err != nil {
 		t.Fatalf("resolveDefaultGCX: %v", err)
@@ -147,7 +147,7 @@ func TestResolveDefaultGCXFallsBackForOlderPathVersion(t *testing.T) {
 	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
 
 	gcxBin := fakeGCXOnPath(t, "0.4.2")
-	fs := gcxRuntimeFlags(cacheDir, "auto")
+	fs := gcxRuntimeFlags(cacheDir, gcxDownloadPolicyAuto)
 	got, err := resolveDefaultGCX(fs, gcxBin)
 	if err != nil {
 		t.Fatalf("resolveDefaultGCX: %v", err)
@@ -163,7 +163,7 @@ func TestResolveDefaultGCXRejectsOlderPathVersionWhenDownloadsDisabled(t *testin
 	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
 
 	gcxBin := fakeGCXOnPath(t, "0.4.2")
-	fs := gcxRuntimeFlags(t.TempDir(), "never")
+	fs := gcxRuntimeFlags(t.TempDir(), gcxDownloadPolicyNever)
 	if _, err := resolveDefaultGCX(fs, gcxBin); err == nil {
 		t.Fatal("expected minimum version error")
 	}
@@ -175,7 +175,7 @@ func TestResolveDefaultGCXExplicitPathOverridesMinimum(t *testing.T) {
 	t.Cleanup(func() { MinimumGCXVersion = oldVersion })
 
 	gcxBin := fakeGCXOnPath(t, "0.4.2")
-	fs := gcxRuntimeFlags(t.TempDir(), "never")
+	fs := gcxRuntimeFlags(t.TempDir(), gcxDownloadPolicyNever)
 	if err := fs.Set("gcx", gcxBin); err != nil {
 		t.Fatal(err)
 	}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -130,7 +130,7 @@ func addRunFlags(fs *pflag.FlagSet) {
 	fs.String("config", "oats-config.yaml", "path to oats-config.yaml")
 	fs.String("gcx", "gcx", "path to gcx binary (PATH-resolved if a bare name)")
 	fs.String("gcx-version", "", "download and use this gcx release (for example, 0.4.3)")
-	fs.String("gcx-download", defaultGCXDownloadPolicy(), "gcx fallback download policy: auto | never")
+	fs.String("gcx-download", defaultGCXDownloadPolicy(), fmt.Sprintf("gcx fallback download policy: %s | %s", gcxDownloadPolicyAuto, gcxDownloadPolicyNever))
 	fs.String("format", "text", "output format: text | ndjson")
 	fs.String("tags", "", "comma-separated tag any-match")
 	fs.Duration("timeout", 30*time.Second, "per-assertion timeout")

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -129,7 +129,11 @@ func newRootCmd(exit *int) *cobra.Command {
 func addRunFlags(fs *pflag.FlagSet) {
 	fs.String("config", "oats-config.yaml", "path to oats-config.yaml")
 	fs.String("gcx", "gcx", "path to gcx binary (PATH-resolved if a bare name)")
-	fs.String("gcx-version", "", "download and use this gcx release (for example, 0.4.3)")
+	gcxVersionHelp := "download and use this gcx release"
+	if MinimumGCXVersion != "" {
+		gcxVersionHelp = fmt.Sprintf("%s (for example, %s)", gcxVersionHelp, MinimumGCXVersion)
+	}
+	fs.String("gcx-version", "", gcxVersionHelp)
 	fs.String("gcx-download", defaultGCXDownloadPolicy(), fmt.Sprintf("gcx fallback download policy: %s | %s", gcxDownloadPolicyAuto, gcxDownloadPolicyNever))
 	fs.String("format", "text", "output format: text | ndjson")
 	fs.String("tags", "", "comma-separated tag any-match")

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -58,10 +58,10 @@ import (
 // -ldflags "-X github.com/grafana/oats/internal/cli.Version=vX.Y.Z".
 var Version = "dev"
 
-// DefaultGCXVersion is the gcx version pinned by the build. Release and mise
-// builds inject it with -ldflags so oats can provide a reproducible fallback
-// when gcx is not already available on PATH.
-var DefaultGCXVersion = ""
+// MinimumGCXVersion is the minimum gcx version accepted from PATH by the
+// build. Release and mise builds inject it with -ldflags so oats can provide a
+// reproducible fallback when gcx is missing or older than this version.
+var MinimumGCXVersion = ""
 
 type suiteResult struct {
 	pass int

--- a/scripts/build-oats.sh
+++ b/scripts/build-oats.sh
@@ -8,5 +8,5 @@ gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 mkdir -p "$(dirname "$output")"
 GOWORK=off go -C "$root" build \
 	-buildvcs=false \
-	-ldflags "-X github.com/grafana/oats/internal/cli.DefaultGCXVersion=$gcx_version" \
+	-ldflags "-X github.com/grafana/oats/internal/cli.MinimumGCXVersion=$gcx_version" \
 	-o "$output" .

--- a/tests/e2e/cases/cli/gcx-min-version/files/bin/gcx
+++ b/tests/e2e/cases/cli/gcx-min-version/files/bin/gcx
@@ -1,0 +1,2 @@
+#!/bin/sh
+printf 'gcx version 0.0.1 built from e2e\n'

--- a/tests/e2e/cases/cli/gcx-min-version/files/oats-case.yaml
+++ b/tests/e2e/cases/cli/gcx-min-version/files/oats-case.yaml
@@ -1,0 +1,13 @@
+name: gcx-min-version
+fixture:
+  remote:
+    endpoint: http://127.0.0.1:4318
+seed:
+  type: inline-otlp
+  logs:
+    - service: gcx-min-version
+      body: gcx-min-version
+expected:
+  logs:
+    - logql: '{service_name="gcx-min-version"}'
+      contains: gcx-min-version

--- a/tests/e2e/cases/cli/gcx-min-version/files/oats-case.yaml
+++ b/tests/e2e/cases/cli/gcx-min-version/files/oats-case.yaml
@@ -8,6 +8,8 @@ seed:
     - service: gcx-min-version
       body: gcx-min-version
 expected:
+  # This assertion is only a validation sentinel: gcx resolution fails before
+  # the fixture, seed, or assertion can run.
   logs:
     - logql: '{service_name="gcx-min-version"}'
       contains: gcx-min-version

--- a/tests/e2e/cases/cli/gcx-min-version/files/oats-config.yaml
+++ b/tests/e2e/cases/cli/gcx-min-version/files/oats-config.yaml
@@ -1,0 +1,3 @@
+meta:
+  version: 3
+cases: ["oats-case.yaml"]

--- a/tests/e2e/cases/cli/gcx-min-version/test.yaml
+++ b/tests/e2e/cases/cli/gcx-min-version/test.yaml
@@ -1,0 +1,19 @@
+name: gcx-min-version
+tags: [cli, gcx]
+
+# An implicit PATH lookup must reject a gcx older than the build-time minimum.
+# The fake binary is prepended to PATH by the e2e harness; --gcx-download never
+# keeps this check offline and makes the expected error deterministic.
+run:
+  command: "{{OATS}}"
+  args:
+    - --config
+    - "{{CASE_DIR}}/files/oats-config.yaml"
+    - --gcx-download
+    - never
+
+expect:
+  exit_code: 2
+  stderr_contains:
+    - "gcx on PATH is"
+    - "automatic download is disabled"


### PR DESCRIPTION
## Summary

- treat the build-embedded gcx version as the minimum accepted version for the implicit `gcx` lookup
- use the PATH binary when it meets the minimum; otherwise fall back to the verified release when downloads are allowed
- fail clearly in `--gcx-download never` environments instead of silently using an older local gcx
- keep explicit `--gcx` and `--gcx-version` overrides authoritative
- use the existing `github.com/hashicorp/go-version` SemVer comparison instead of maintaining prerelease ordering logic
- add a CLI e2e case that rejects an older PATH gcx without network access
- add version-resolution unit tests and update the CLI/CI documentation

This is a focused follow-up to the v2 integration stack and targets `v2-integration` alongside #386–#391.

## Validation

- `mise run lint`
- `mise run test`
- `GOFLAGS=-buildvcs=false go test ./tests/e2e -run '^TestCases$' -count=1` (skips locally because Docker is unavailable)
- manual built-binary check of the older PATH gcx case
