### PR TITLE
docs: record architecture decisions and contributor guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,9 @@
 
 This file provides guidance to AI coding agents when working with code in this repository.
 
+For durable architecture and product decisions, see the
+[architecture decision records](docs/adr/README.md).
+
 ## Project Overview
 
 OATs (OpenTelemetry Acceptance Tests) is a declarative test framework for

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,7 +2,7 @@
 
 This file provides guidance to AI coding agents when working with code in this repository.
 
-For a broader contributor orientation, see [docs/repository-guide.md](docs/repository-guide.md).
+For a broader contributor orientation, see [CONTRIBUTING.md](CONTRIBUTING.md).
 
 ## Project Overview
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 This file provides guidance to AI coding agents when working with code in this repository.
 
+For a broader contributor orientation, see [docs/repository-guide.md](docs/repository-guide.md).
+
 ## Project Overview
 
 OATs (OpenTelemetry Acceptance Tests) is a declarative test framework for

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -16,7 +16,9 @@ mise run check       # lint + test
 
 For the user-facing surface, read [CLI](docs/cli.md), [case reference](docs/case-reference.md),
 [CI guidance](docs/ci.md), and [upgrading](UPGRADING.md). The root
-[AGENTS.md](AGENTS.md) contains the concise coding-agent instructions.
+[AGENTS.md](AGENTS.md) contains the concise coding-agent instructions. Durable
+architecture and product decisions are recorded in the
+[architecture decision records](https://github.com/grafana/oats/pull/393).
 
 ## Architecture at a glance
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -10,7 +10,7 @@ then links to detailed references for further information.
 mise run build       # build oats with the gcx version from mise.toml
 mise run test        # unit and integration tests (excludes tests/e2e)
 mise run e2e-test    # real-stack e2e cases; requires Docker or Podman
-mise run lint        # Flint's aggregate lint/check command
+mise run lint:fix    # Auto-fix Flint issues
 mise run check       # lint + test
 ```
 
@@ -37,14 +37,15 @@ architecture and product decisions are recorded in the
 
 Before opening or updating a pull request:
 
-1. Run the relevant tests and `mise run lint` locally.
+1. Run the relevant tests and `mise run lint:fix` locally. CI uses `mise run lint`
+   to verify the result.
 2. Use [signed commits](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-signed-commits).
    See GitHub's [commit signature setup](https://docs.github.com/authentication/managing-commit-signature-verification/about-commit-signature-verification)
    and [verification guidance](https://docs.github.com/authentication/troubleshooting-commit-signature-verification/checking-your-commit-and-tag-signature-verification-status).
-   Do not bypass hooks with `--no-verify`.
-3. Include a concise summary, the validation performed, and any follow-up work
+3. Use a semantic pull request title, such as `docs: improve contributor guidance`.
+4. Include a concise summary, the validation performed, and any follow-up work
    in the pull request description.
-4. Keep review updates additive where possible. Avoid force-pushing review
+5. Keep review updates additive where possible. Avoid force-pushing review
    changes unless repairing or restacking history requires it.
 
 Sign Grafana's [Contributor License Agreement (CLA)](https://cla-assistant.io/grafana/oats)

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -99,8 +99,9 @@ fixture safety gate allows it.
 - `mise run test` runs all Go packages except `tests/e2e`.
 - `tests/e2e` is a data-driven harness. Each case directory has a `test.yaml`
   plus its generated/config/fixture files; use `OATS_E2E_FILTER` to narrow a
-  local run. The harness builds the real oats and gcx tools and uses Docker for
-  compose/k3d fixtures.
+  local run. The harness builds the real oats and gcx tools and uses the
+  selected Docker or Podman engine for Compose fixtures; k3d remains
+  Docker-backed.
 - `.github/workflows/lint.yml`, `build.yml`, and `test.yml` provide fast PR
   feedback. `.github/workflows/e2e_test.yml` runs the real-stack matrix and ends
   in one `e2e` gate job. Release builds use `.github/workflows/release.yml` and

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -42,7 +42,8 @@ Before opening or updating a pull request:
 2. Use [signed commits](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-signed-commits).
    See GitHub's [commit signature setup](https://docs.github.com/authentication/managing-commit-signature-verification/about-commit-signature-verification)
    and [verification guidance](https://docs.github.com/authentication/troubleshooting-commit-signature-verification/checking-your-commit-and-tag-signature-verification-status).
-3. Use a semantic pull request title, such as `docs: improve contributor guidance`.
+3. Use a [semantic pull request title](https://www.conventionalcommits.org/en/v1.0.0/#summary),
+   such as `docs: improve contributor guidance`.
 4. Include a concise summary, the validation performed, and any follow-up work
    in the pull request description.
 5. Keep review updates additive where possible. Avoid force-pushing review

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,15 +1,16 @@
 # Contributing to OATs
 
-This is the starting point for contributing to OATs. It covers the development
-workflow and repository architecture, then links to detailed references without
-duplicating the case schema or CLI reference.
+This is the starting point for contributing to OATs. It covers how to choose and
+prepare a change, the development workflow, and the repository architecture,
+then links to detailed references without duplicating the case schema or CLI
+reference.
 
 ## Start here
 
 ```sh
 mise run build       # build oats with the gcx version from mise.toml
 mise run test        # unit and integration tests (excludes tests/e2e)
-mise run e2e-test    # real-stack e2e cases; requires Docker
+mise run e2e-test    # real-stack e2e cases; requires Docker or Podman
 mise run lint        # Flint's aggregate lint/check command
 mise run check       # lint + test
 ```
@@ -20,25 +21,43 @@ For the user-facing surface, read [CLI](docs/cli.md), [case reference](docs/case
 architecture and product decisions are recorded in the
 [architecture decision records](docs/adr/README.md).
 
+## Choosing a change
+
+- Look for an existing issue or discussion before starting a non-trivial
+  change. If there is no suitable issue, open one first so the scope and
+  expected behavior can be agreed on.
+- Claim the work in the issue or discussion, then keep the pull request focused
+  on that change. Avoid bundling unrelated cleanup with a feature or fix.
+- For architectural or product changes, read the relevant
+  [architecture decision records](docs/adr/README.md) and add or update an ADR
+  when the decision should remain durable.
+
+## Submitting a pull request
+
+Before opening or updating a pull request:
+
+1. Run the relevant tests and `mise run lint` locally.
+2. Use signed commits; do not bypass hooks with `--no-verify`.
+3. Include a concise summary, the validation performed, and any follow-up work
+   in the pull request description.
+4. Keep review updates additive where possible. Avoid force-pushing review
+   changes unless repairing or restacking history requires it.
+
+Grafana's CLA bot will report whether the contributor agreement is complete.
+Address its request before the pull request can be merged.
+
 ## Architecture at a glance
 
 The normal run flows left to right:
 
-```text
-oats-config.yaml + case YAML
-        │
-        ▼
-discovery.PlanRun ── groups cases by fixture identity
-        │
-        ▼
-fixture.Start / WaitForReady
-        │
-        ▼
-runner ── seed ──> OTLP endpoint
-        │
-        ├──────────> gcx ──> Grafana datasources
-        │
-        └──────────> cache + report (text or NDJSON)
+```mermaid
+flowchart LR
+    A[Config and case YAML] --> B[discovery.PlanRun]
+    B --> C[fixture.Start / WaitForReady]
+    C --> D[runner]
+    D --> E[seed to OTLP]
+    D --> F[gcx queries and assertions]
+    D --> G[cache and report]
 ```
 
 | Area                                | Responsibility                                                         | Start with               |

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,7 +1,8 @@
-# Repository guide
+# Contributing to OATs
 
-This is the orientation page for contributors. It links to the detailed
-references without duplicating the case schema or CLI reference.
+This is the starting point for contributing to OATs. It covers the development
+workflow and repository architecture, then links to detailed references without
+duplicating the case schema or CLI reference.
 
 ## Start here
 
@@ -13,9 +14,9 @@ mise run lint        # Flint's aggregate lint/check command
 mise run check       # lint + test
 ```
 
-For the user-facing surface, read [CLI](cli.md), [case reference](case-reference.md),
-[CI guidance](ci.md), and [upgrading](../UPGRADING.md). The root
-[AGENTS.md](../AGENTS.md) contains the concise coding-agent instructions.
+For the user-facing surface, read [CLI](docs/cli.md), [case reference](docs/case-reference.md),
+[CI guidance](docs/ci.md), and [upgrading](UPGRADING.md). The root
+[AGENTS.md](AGENTS.md) contains the concise coding-agent instructions.
 
 ## Architecture at a glance
 
@@ -59,7 +60,7 @@ fixture safety gate allows it.
 ## CLI, environment, and gcx
 
 - Every run flag has an `OATS_` environment equivalent; command-line values win.
-  The complete table is in [cli.md](cli.md).
+  The complete table is in [CLI reference](docs/cli.md).
 - `gcx` is a separate executable. OATS does not bundle it into the oats binary.
   Release and mise builds embed the pinned gcx version so a missing default gcx
   can be downloaded, checksum-verified, and cached. `--gcx-version` explicitly
@@ -70,7 +71,7 @@ fixture safety gate allows it.
   GoReleaser receives the same value through `GCX_VERSION` in the release
   workflow. Do not hard-code a second gcx version in a script or workflow.
 - `OATS_GHA_ANNOTATIONS` controls the optional GitHub Actions error annotations
-  emitted by the text reporter. See [ci.md](ci.md).
+  emitted by the text reporter. See [CI guidance](docs/ci.md).
 
 ## Test and CI map
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,8 +2,7 @@
 
 This is the starting point for contributing to OATs. It covers how to choose and
 prepare a change, the development workflow, and the repository architecture,
-then links to detailed references without duplicating the case schema or CLI
-reference.
+then links to detailed references for further information.
 
 ## Start here
 
@@ -25,7 +24,9 @@ architecture and product decisions are recorded in the
 
 - Look for an existing issue or discussion before starting a non-trivial
   change. If there is no suitable issue, open one first so the scope and
-  expected behavior can be agreed on.
+  expected behavior can be agreed on with the maintainers.
+- For smaller tasks, browse the [help wanted issues](https://github.com/grafana/oats/issues?q=state%3Aopen%20label%3A%22help%20wanted%22)
+  for work that is ready to pick up.
 - Claim the work in the issue or discussion, then keep the pull request focused
   on that change. Avoid bundling unrelated cleanup with a feature or fix.
 - For architectural or product changes, read the relevant
@@ -37,14 +38,18 @@ architecture and product decisions are recorded in the
 Before opening or updating a pull request:
 
 1. Run the relevant tests and `mise run lint` locally.
-2. Use signed commits; do not bypass hooks with `--no-verify`.
+2. Use [signed commits](https://docs.github.com/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/about-protected-branches#require-signed-commits).
+   See GitHub's [commit signature setup](https://docs.github.com/authentication/managing-commit-signature-verification/about-commit-signature-verification)
+   and [verification guidance](https://docs.github.com/authentication/troubleshooting-commit-signature-verification/checking-your-commit-and-tag-signature-verification-status).
+   Do not bypass hooks with `--no-verify`.
 3. Include a concise summary, the validation performed, and any follow-up work
    in the pull request description.
 4. Keep review updates additive where possible. Avoid force-pushing review
    changes unless repairing or restacking history requires it.
 
-Grafana's CLA bot will report whether the contributor agreement is complete.
-Address its request before the pull request can be merged.
+Sign Grafana's [Contributor License Agreement (CLA)](https://cla-assistant.io/grafana/oats)
+before submitting if possible. The CLA bot will report whether the contributor
+agreement is complete; address its request before the pull request can be merged.
 
 ## Architecture at a glance
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@
   <a href="docs/cli.md">CLI</a> ·
   <a href="docs/case-reference.md">Test Case Syntax</a> ·
   <a href="docs/ci.md">CI</a> ·
-  <a href="docs/repository-guide.md">Repository Guide</a> ·
+  <a href="CONTRIBUTING.md">Contributing</a> ·
   <a href="UPGRADING.md">Upgrading</a>
 </p>
 <!-- markdownlint-enable MD033 MD041 -->
@@ -141,7 +141,7 @@ No app of your own yet? A case can seed telemetry directly with
   full config + case shape (fixtures, seed modes, assertion vocabulary, custom checks)
 - [docs/ci.md](docs/ci.md) — installing and running OATS in CI, plus result
   caching and its caveats
-- [docs/repository-guide.md](docs/repository-guide.md) — contributor orientation:
+- [CONTRIBUTING.md](CONTRIBUTING.md) — contributor orientation:
   architecture, CLI/env/tooling map, CI/e2e flow, and common gotchas
 - [UPGRADING.md](UPGRADING.md) — migrating older (schema-2) repos to v3
 - [AGENTS.md](AGENTS.md) — for contributors and coding agents working *on*

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@
   <a href="docs/cli.md">CLI</a> ·
   <a href="docs/case-reference.md">Test Case Syntax</a> ·
   <a href="docs/ci.md">CI</a> ·
+  <a href="docs/repository-guide.md">Repository Guide</a> ·
   <a href="UPGRADING.md">Upgrading</a>
 </p>
 <!-- markdownlint-enable MD033 MD041 -->
@@ -140,6 +141,8 @@ No app of your own yet? A case can seed telemetry directly with
   full config + case shape (fixtures, seed modes, assertion vocabulary, custom checks)
 - [docs/ci.md](docs/ci.md) — installing and running OATS in CI, plus result
   caching and its caveats
+- [docs/repository-guide.md](docs/repository-guide.md) — contributor orientation:
+  architecture, CLI/env/tooling map, CI/e2e flow, and common gotchas
 - [UPGRADING.md](UPGRADING.md) — migrating older (schema-2) repos to v3
 - [AGENTS.md](AGENTS.md) — for contributors and coding agents working *on*
   OATS (build, layout, conventions)

--- a/docs/adr/0001-container-engines.md
+++ b/docs/adr/0001-container-engines.md
@@ -1,0 +1,56 @@
+# ADR-0001: Container engines for fixture-backed tests
+
+- **Status:** Proposed
+- **Date:** 2026-07-18
+
+## Context
+
+OATS currently shells out to Docker, Docker Compose, k3d, and kubectl from its
+fixture lifecycle. That makes the fixture package look pluggable while still
+coupling it to one container engine. It also forces users who prefer rootless
+Podman to change their environment or maintain wrappers.
+
+The case schema should describe the test and its fixture, not the host's
+container-engine choice. Compose and k3d also have different capabilities:
+k3d is a Kubernetes-in-Docker workflow, while Compose can be implemented by
+multiple container engines.
+
+## Decision
+
+OATS will introduce a narrow internal container-engine layer and support Docker
+and Podman as first-class engines for Compose fixtures. The layer will:
+
+- centralize command execution, environment handling, logging, cancellation,
+  and cleanup;
+- expose Compose lifecycle operations such as up, port lookup, exec, logs, and
+  teardown through an adapter;
+- keep engine selection out of the case schema; and
+- preserve Docker as a supported, explicit option.
+
+The host-level selection will be exposed through `--container-runtime` and
+`OATS_CONTAINER_RUNTIME`, with `docker`, `podman`, and `auto` as the intended
+values. `auto` should prefer Podman when it is available and fall back to
+Docker; an explicit engine must not silently fall back to another engine.
+
+The first alternative-engine target is Compose with rootless Podman. k3d and
+its Docker image-import path remain a separate adapter until reliable Podman
+coverage exists for that workflow. Apple Container is not treated as a
+Docker-compatible binary replacement; it would require its own adapter if a
+consumer needs it.
+
+## Consequences
+
+- Compose fixtures can be used in environments that do not expose a Docker
+  socket.
+- The implementation needs an engine compatibility test matrix; swapping the
+  executable name is not sufficient because Compose providers and flags can
+  differ.
+- CI should select its engine explicitly for reproducible runs, while local
+  `auto` mode can prefer a rootless Podman installation.
+- No case-file migration or schema change is required.
+
+## Revisit
+
+Promote this ADR to **Accepted** after the Docker and rootless-Podman Compose
+paths pass the same representative e2e suite. Add k3d/Podman or Apple Container
+adapters only with a concrete implementation and CI coverage.

--- a/docs/adr/0001-container-engines.md
+++ b/docs/adr/0001-container-engines.md
@@ -8,7 +8,8 @@
 OATS currently shells out to Docker, Docker Compose, k3d, and kubectl from its
 fixture lifecycle. That makes the fixture package look pluggable while still
 coupling it to one container engine. It also forces users who prefer rootless
-Podman to change their environment or maintain wrappers.
+Podman, or other similar technologies, to change their environment or maintain
+wrappers.
 
 The case schema should describe the test and its fixture, not the host's
 container-engine choice. Compose and k3d also have different capabilities:
@@ -34,9 +35,12 @@ Docker; an explicit engine must not silently fall back to another engine.
 
 The first alternative-engine target is Compose with rootless Podman. k3d and
 its Docker image-import path remain a separate adapter until reliable Podman
-coverage exists for that workflow. Apple Container is not treated as a
-Docker-compatible binary replacement; it would require its own adapter if a
-consumer needs it.
+coverage exists for that workflow. Environments such as
+[WSL Containers](https://devblogs.microsoft.com/commandline/wsl-container-is-now-available-for-public-preview/)
+provide a distinct `wslc`/`container` CLI and are therefore outside this
+decision; supporting them would require a separate adapter. Apple Container is
+likewise not treated as a Docker-compatible binary replacement; it would
+require its own adapter if a consumer needs it.
 
 ## Consequences
 

--- a/docs/adr/0001-container-engines.md
+++ b/docs/adr/0001-container-engines.md
@@ -1,6 +1,6 @@
 # ADR-0001: Container engines for fixture-backed tests
 
-- **Status:** Proposed
+- **Status:** Accepted
 - **Date:** 2026-07-18
 
 ## Context
@@ -49,8 +49,12 @@ consumer needs it.
   `auto` mode can prefer a rootless Podman installation.
 - No case-file migration or schema change is required.
 
+## Implementation
+
+The Docker and rootless-Podman Compose paths are covered by the e2e matrix in
+[PR #394](https://github.com/grafana/oats/pull/394).
+
 ## Revisit
 
-Promote this ADR to **Accepted** after the Docker and rootless-Podman Compose
-paths pass the same representative e2e suite. Add k3d/Podman or Apple Container
-adapters only with a concrete implementation and CI coverage.
+Add k3d/Podman or Apple Container adapters only with a concrete implementation
+and CI coverage.

--- a/docs/adr/0002-oats-init.md
+++ b/docs/adr/0002-oats-init.md
@@ -1,0 +1,38 @@
+# ADR-0002: Defer `oats init`
+
+- **Status:** Deferred
+- **Date:** 2026-07-18
+
+## Context
+
+A project generator could create an `oats-config.yaml`, a starter case, mise
+pins, and a GitHub Actions workflow. Only the first two are OATS-owned facts;
+the application Compose file, tool-version policy, and CI workflow are
+consumer-specific choices.
+
+OATS already provides a copyable example and `oats migrate` for existing legacy
+projects. Generating a large set of policy files before seeing a real consumer
+use the v3 flow risks producing stale or misleading boilerplate.
+
+## Decision
+
+Do not add a full `oats init` command to the initial v3 integration. Revisit it
+after at least one downstream consumer has used the new flow and identified
+repeated onboarding friction.
+
+If a generator becomes necessary, start with a thin scaffold that creates only
+an `oats-config.yaml` and a runnable starter `oats-case.yaml`. mise and CI
+workflow files should be explicit opt-in templates, not silent defaults.
+
+## Consequences
+
+- The initial CLI stays smaller and avoids owning consumer project policy.
+- The examples and migration command remain the onboarding surface for now.
+- A future `init` design should be based on observed downstream repetition,
+  rather than guesses about application layout.
+
+## Revisit trigger
+
+Implement a thin scaffold when a downstream consumer has repeated the same
+setup steps or when multiple users request project generation with compatible
+assumptions.

--- a/docs/adr/0003-parallel-fixture-isolation.md
+++ b/docs/adr/0003-parallel-fixture-isolation.md
@@ -1,0 +1,38 @@
+# ADR-0003: Preserve backend isolation for parallel fixture groups
+
+- **Status:** Accepted
+- **Date:** 2026-07-18
+
+## Context
+
+OATS can run derived fixture groups concurrently. A Compose or k3d fixture is
+expensive, so sharing one LGTM backend across groups appears attractive. That
+would change the isolation boundary, however: unscoped TraceQL, LogQL, or
+PromQL could observe another group's telemetry and produce false passes or
+failures.
+
+The current design gives each booted local fixture its own backend and uses
+unique project names and ephemeral host ports where needed.
+
+## Decision
+
+Keep parallelism hermetic: each parallel-safe group owns its own local backend.
+`--parallel N` remains explicit and defaults to one. Compose app-seed groups
+are parallel-safe only when OATS manages an ephemeral app port; k3d remains
+serial until its port-forward and cluster model are made safe.
+
+Do not add shared-LGTM execution or make the default parallelism automatically
+scale with CPU count in the initial integration.
+
+## Consequences
+
+- Parallel runs consume more memory because each local LGTM backend is separate.
+- Existing queries do not need hidden service-name scoping changes.
+- The behavior is predictable and preserves the current hermeticity guarantee.
+
+## Revisit trigger
+
+Reconsider a shared backend only when a real consumer is resource-bound by
+hermetic parallelism and can accept an explicit opt-in mode plus validation of
+query isolation. Reconsider automatic parallelism after CI wall-time and
+resource measurements provide a safe default for the relevant fixture types.

--- a/docs/adr/0004-cache-retention-and-invalidation.md
+++ b/docs/adr/0004-cache-retention-and-invalidation.md
@@ -8,11 +8,16 @@
 OATS has a skip-when-unchanged cache for green cases. A long-lived cache could
 also be bounded by entry count or size, and a consumer could include built
 image digests in the key. Both add configuration or integration work, while
-most CI users already have short-lived caches and pinned tool versions.
+we do not currently have measurements from long-lived consumer cache
+directories showing that either feature is needed.
 
 The cache currently hashes the case, fixture configuration, gcx version, and
 OATS version. It uses TTL-based expiry, lazy removal of expired entries, and an
 explicit `oats cache clear` command.
+
+The existing unit tests cover TTL expiry and manual clearing. This ADR is a
+scope decision based on the current implementation and lack of observed demand,
+not a claim that TTL provides a hard bound on cache size.
 
 ## Decision
 

--- a/docs/adr/0004-cache-retention-and-invalidation.md
+++ b/docs/adr/0004-cache-retention-and-invalidation.md
@@ -1,0 +1,37 @@
+# ADR-0004: Keep cache retention simple and make invalidation explicit
+
+- **Status:** Accepted
+- **Date:** 2026-07-18
+
+## Context
+
+OATS has a skip-when-unchanged cache for green cases. A long-lived cache could
+also be bounded by entry count or size, and a consumer could include built
+image digests in the key. Both add configuration or integration work, while
+most CI users already have short-lived caches and pinned tool versions.
+
+The cache currently hashes the case, fixture configuration, gcx version, and
+OATS version. It uses TTL-based expiry, lazy removal of expired entries, and an
+explicit `oats cache clear` command.
+
+## Decision
+
+Use TTL expiry plus manual clearing as the initial cache-retention policy. Do
+not add an LRU/size cap or automatic image-digest discovery now.
+
+Document the floating-image-tag caveat. Consumers that rebuild an image under
+the same tag must either pin the image by digest, avoid persisting the cache,
+or provide a future digest value through the cache key's extension point.
+
+## Consequences
+
+- The cache remains simple and predictable across platforms.
+- A pathological long-lived cache may grow until TTL eviction occurs.
+- Consumers are responsible for avoiding stale results when fixture contents
+  are not represented by the fixture configuration.
+
+## Revisit triggers
+
+Add a size/count cap after observing cache growth in a long-lived environment.
+Fold image digests into the key when a real consumer uses floating image tags
+with a persisted cache and cannot adopt digest pinning.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -1,0 +1,17 @@
+# Architecture decision records
+
+This directory records durable OATS architecture and product decisions. ADRs are
+not task trackers: implementation work belongs in pull requests and concrete
+follow-up issues in the owning repository.
+
+## Statuses
+
+- **Proposed** — the context and intended direction are recorded, but the
+  decision is still open to review.
+- **Accepted** — this is the current decision and should guide implementation.
+- **Deferred** — we deliberately chose not to build this now; the ADR records
+  the trigger for revisiting it.
+- **Superseded** — a later ADR replaces this decision.
+
+When a decision changes, keep the old ADR and link the replacement rather than
+rewriting history.

--- a/docs/adr/README.md
+++ b/docs/adr/README.md
@@ -11,6 +11,8 @@ follow-up issues in the owning repository.
 - **Accepted** — this is the current decision and should guide implementation.
 - **Deferred** — we deliberately chose not to build this now; the ADR records
   the trigger for revisiting it.
+- **Declined** — the proposal was considered and declined; no implementation
+  is planned unless a new proposal supersedes this decision.
 - **Superseded** — a later ADR replaces this decision.
 
 When a decision changes, keep the old ADR and link the replacement rather than

--- a/docs/repository-guide.md
+++ b/docs/repository-guide.md
@@ -1,0 +1,105 @@
+# Repository guide
+
+This is the orientation page for contributors. It links to the detailed
+references without duplicating the case schema or CLI reference.
+
+## Start here
+
+```sh
+mise run build       # build oats with the gcx version from mise.toml
+mise run test        # unit and integration tests (excludes tests/e2e)
+mise run e2e-test    # real-stack e2e cases; requires Docker
+mise run lint        # Flint's aggregate lint/check command
+mise run check       # lint + test
+```
+
+For the user-facing surface, read [CLI](cli.md), [case reference](case-reference.md),
+[CI guidance](ci.md), and [upgrading](../UPGRADING.md). The root
+[AGENTS.md](../AGENTS.md) contains the concise coding-agent instructions.
+
+## Architecture at a glance
+
+The normal run flows left to right:
+
+```text
+oats-config.yaml + case YAML
+        │
+        ▼
+discovery.PlanRun ── groups cases by fixture identity
+        │
+        ▼
+fixture.Start / WaitForReady
+        │
+        ▼
+runner ── seed ──> OTLP endpoint
+        │
+        ├──────────> gcx ──> Grafana datasources
+        │
+        └──────────> cache + report (text or NDJSON)
+```
+
+| Area                                | Responsibility                                                         | Start with               |
+| ----------------------------------- | ---------------------------------------------------------------------- | ------------------------ |
+| `casefile/`                         | v3 YAML case/config data and validation                                | `casefile/case.go`       |
+| `discovery/`                        | config loading, filtering, and fixture-boot grouping                   | `discovery/discovery.go` |
+| `fixture/`                          | compose/k3d lifecycle, readiness, endpoints, and parallel-safety gates | `fixture/fixture.go`     |
+| `runner/`                           | case execution: seed, poll, assertions, cache, and reporting           | `runner/runner.go`       |
+| `seed/`                             | inline OTLP and application-input seeding                              | `seed/seed.go`           |
+| `engine/` / `signalcmd/`            | gcx invocation and signal-specific command construction                | `engine/gcx.go`          |
+| `report/`                           | text/NDJSON event stream and GitHub annotations                        | `report/event.go`        |
+| `internal/cli/`                     | Cobra commands, flags, env mapping, and orchestration                  | `internal/cli/main.go`   |
+| `internal/legacyyaml/` / `migrate/` | legacy schema parsing and v2→v3 migration only                         | `migrate/migrate.go`     |
+| `tests/e2e/`                        | black-box cases run against real stacks and tools                      | `tests/e2e/e2e_test.go`  |
+
+The current format has one schema version (`meta.version: 3`). Cases carry their
+own fixture; OATS derives fixture-boot groups, boots each fixture once, and runs
+the group's cases serially. Different groups may run concurrently when the
+fixture safety gate allows it.
+
+## CLI, environment, and gcx
+
+- Every run flag has an `OATS_` environment equivalent; command-line values win.
+  The complete table is in [cli.md](cli.md).
+- `gcx` is a separate executable. OATS does not bundle it into the oats binary.
+  Release and mise builds embed the pinned gcx version so a missing default gcx
+  can be downloaded, checksum-verified, and cached. `--gcx-version` explicitly
+  selects a release; `--gcx-download never` (or `OATS_GCX_DOWNLOAD=never`) keeps
+  CI and air-gapped runs from downloading.
+- The pin is read from `mise.toml` by `scripts/gcx-version.sh`. Local builds use
+  `scripts/build-oats.sh`; local tool setup uses `scripts/build-local-tools.sh`;
+  GoReleaser receives the same value through `GCX_VERSION` in the release
+  workflow. Do not hard-code a second gcx version in a script or workflow.
+- `OATS_GHA_ANNOTATIONS` controls the optional GitHub Actions error annotations
+  emitted by the text reporter. See [ci.md](ci.md).
+
+## Test and CI map
+
+- `mise run test` runs all Go packages except `tests/e2e`.
+- `tests/e2e` is a data-driven harness. Each case directory has a `test.yaml`
+  plus its generated/config/fixture files; use `OATS_E2E_FILTER` to narrow a
+  local run. The harness builds the real oats and gcx tools and uses Docker for
+  compose/k3d fixtures.
+- `.github/workflows/lint.yml`, `build.yml`, and `test.yml` provide fast PR
+  feedback. `.github/workflows/e2e_test.yml` runs the real-stack matrix and ends
+  in one `e2e` gate job. Release builds use `.github/workflows/release.yml` and
+  `.goreleaser.yml`.
+- Examples are part of the build/e2e contract, not documentation-only snippets.
+  Keep their compose files, Dockerfiles, manifests, scripts, and case files
+  together when adding or changing an example.
+
+## Common gotchas
+
+1. **Do not reintroduce config-level suites.** The v3 config is `meta` + `cases`
+   - optional cache; fixture data belongs on each case.
+2. **Do not use `docker-compose`.** The supported command is `docker compose`;
+   the compose helper owns project names and generated ports for isolation.
+3. **Cache keys do not hash fixture contents.** A floating app image tag can
+   produce a stale green result. Pin image digests or avoid persisting the cache
+   until the image digest is included in `cache.Key.Extra`.
+4. **Keep gcx and oats version wiring together.** If the mise pin changes,
+   `scripts/gcx-version.sh`, local builds, releases, and CI should all continue
+   to derive the same value.
+5. **Prefer focused changes against the current integration base.** Run the
+   relevant unit tests and lint before pushing; use signed commits and normal
+   pushes, and avoid force-pushing review updates unless a true restack requires
+   it.


### PR DESCRIPTION
## Summary

- add a small ADR directory and status conventions
- record the proposed Docker/Podman container-engine direction
- record the decisions to defer `oats init`, preserve hermetic parallelism, and keep cache retention simple
- include the contributor guide and concise coding-agent guidance
- link both contributor and agent guidance to the ADR index

## Why

The v3 work has several architectural decisions that should remain discoverable without turning the issue tracker into a speculative backlog. These ADRs capture both accepted decisions and deliberate deferrals, with explicit revisit triggers.

This combines the documentation scope from #391 with the ADR scope, so the contributor documentation lands together with the ADR links.

## Validation

- `mise run lint`
- CI checks pass
