### PR TITLE
feat(fixture): support Podman Compose runtime

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -62,10 +62,26 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes podman podman-compose
+      - name: Start rootless Podman service
+        if: matrix.shard == 'compose-podman'
+        run: |
+          socket="$XDG_RUNTIME_DIR/podman/podman.sock"
+          mkdir -p "$(dirname "$socket")"
+          podman system service --time=0 "unix://$socket" >"$RUNNER_TEMP/podman-service.log" 2>&1 &
+          echo "DOCKER_HOST=unix://$socket" >> "$GITHUB_ENV"
+          for _ in {1..30}; do
+            if [[ -S "$socket" ]]; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/podman-service.log"
+          exit 1
       - name: Run e2e tests
         # OATS_E2E_FILTER is not part of the matrix to avoid that it shows up in the gh action (too long)
         env:
           OATS_E2E_SHARD: ${{ matrix.shard }}
+          OATS_CONTAINER_RUNTIME: ${{ matrix.shard == 'compose-podman' && 'podman' || 'docker' }}
         run: |
           start_ts="$(date +%s)"
           case "$OATS_E2E_SHARD" in
@@ -130,6 +146,7 @@ jobs:
         env:
           OATS_BIN: ${{ github.workspace }}/.e2e-tools/bin/oats
           GCX_BIN: ${{ github.workspace }}/.e2e-tools/bin/gcx
+          OATS_CONTAINER_RUNTIME: docker
           OATS_EXAMPLE_MODE: ${{ matrix.mode }}
         run: mise run example-test
 
@@ -152,6 +169,20 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes podman podman-compose
+      - name: Start rootless Podman service
+        run: |
+          socket="$XDG_RUNTIME_DIR/podman/podman.sock"
+          mkdir -p "$(dirname "$socket")"
+          podman system service --time=0 "unix://$socket" >"$RUNNER_TEMP/podman-service.log" 2>&1 &
+          echo "DOCKER_HOST=unix://$socket" >> "$GITHUB_ENV"
+          for _ in {1..30}; do
+            if [[ -S "$socket" ]]; then
+              exit 0
+            fi
+            sleep 1
+          done
+          cat "$RUNNER_TEMP/podman-service.log"
+          exit 1
       - name: Download e2e tools
         uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
         with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -81,6 +81,8 @@ jobs:
         # OATS_E2E_FILTER is not part of the matrix to avoid that it shows up in the gh action (too long)
         env:
           OATS_E2E_SHARD: ${{ matrix.shard }}
+          # Keep the CI matrix explicit: hosted runners may have both engines
+          # installed, while auto mode intentionally prefers Podman locally.
           OATS_CONTAINER_RUNTIME: ${{ matrix.shard == 'compose-podman' && 'podman' || 'docker' }}
         run: |
           start_ts="$(date +%s)"
@@ -93,7 +95,6 @@ jobs:
               ;;
             compose-podman)
               export OATS_E2E_FILTER="fixture/compose"
-              export OATS_CONTAINER_RUNTIME=podman
               ;;
             remote)
               export OATS_E2E_FILTER="fixture/remote"

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -40,7 +40,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        shard: [core, compose, remote, k3d-fail, k3d-smoke]
+        shard: [core, compose, compose-podman, remote, k3d-fail, k3d-smoke]
     steps:
       - name: Check out
         uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
@@ -57,6 +57,11 @@ jobs:
           path: .e2e-tools/bin
       - name: Restore e2e tool permissions
         run: chmod +x .e2e-tools/bin/oats .e2e-tools/bin/gcx
+      - name: Install Podman Compose provider
+        if: matrix.shard == 'compose-podman'
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes podman podman-compose
       - name: Run e2e tests
         # OATS_E2E_FILTER is not part of the matrix to avoid that it shows up in the gh action (too long)
         env:
@@ -69,6 +74,10 @@ jobs:
               ;;
             compose)
               export OATS_E2E_FILTER="fixture/compose"
+              ;;
+            compose-podman)
+              export OATS_E2E_FILTER="fixture/compose"
+              export OATS_CONTAINER_RUNTIME=podman
               ;;
             remote)
               export OATS_E2E_FILTER="fixture/remote"
@@ -124,12 +133,46 @@ jobs:
           OATS_EXAMPLE_MODE: ${{ matrix.mode }}
         run: mise run example-test
 
+  # Exercise the Compose adapter with rootless Podman as well as Docker. The
+  # k3d examples stay in the Docker-backed matrix because k3d is a separate
+  # Kubernetes-in-Docker workflow.
+  examples-podman:
+    needs: build-e2e-tools
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0 # v7
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@e6a8b3978addb5a52f2b4cd9d91eafa7f0ab959d # v4.2.0
+        with:
+          version: v2026.7.0
+          sha256: 0744cb3c303baf0d308ff7b112ed41f22abb6029cb5644fd3a8ce74b29f16a68
+      - name: Install Podman Compose provider
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes podman podman-compose
+      - name: Download e2e tools
+        uses: actions/download-artifact@fa0a91b85d4f404e444e00e005971372dc801d16 # v4.1.8
+        with:
+          name: e2e-tools
+          path: .e2e-tools/bin
+      - name: Restore e2e tool permissions
+        run: chmod +x .e2e-tools/bin/oats .e2e-tools/bin/gcx
+      - name: Run Compose examples with Podman
+        env:
+          OATS_BIN: ${{ github.workspace }}/.e2e-tools/bin/oats
+          GCX_BIN: ${{ github.workspace }}/.e2e-tools/bin/gcx
+          OATS_CONTAINER_RUNTIME: podman
+          OATS_EXAMPLE_MODE: compose
+        run: mise run example-test
+
   # Single required check. Branch protection can require just `e2e` instead of
   # every matrix leg, so adding/renaming shards never silently drops coverage.
   # `needs` on the matrix job succeeds only if all its legs did; if: always()
   # makes this run (and go red) even when a dependency fails or is skipped.
   e2e:
-    needs: [test-e2e, examples]
+    needs: [test-e2e, examples, examples-podman]
     if: always()
     runs-on: ubuntu-24.04
     steps:
@@ -137,6 +180,7 @@ jobs:
         env:
           TEST_E2E_RESULT: ${{ needs.test-e2e.result }}
           EXAMPLES_RESULT: ${{ needs.examples.result }}
+          EXAMPLES_PODMAN_RESULT: ${{ needs.examples-podman.result }}
         run: |
-          echo "test-e2e=$TEST_E2E_RESULT examples=$EXAMPLES_RESULT"
-          [ "$TEST_E2E_RESULT" = "success" ] && [ "$EXAMPLES_RESULT" = "success" ]
+          echo "test-e2e=$TEST_E2E_RESULT examples=$EXAMPLES_RESULT examples-podman=$EXAMPLES_PODMAN_RESULT"
+          [ "$TEST_E2E_RESULT" = "success" ] && [ "$EXAMPLES_RESULT" = "success" ] && [ "$EXAMPLES_PODMAN_RESULT" = "success" ]

--- a/.mise/tasks/example-test.sh
+++ b/.mise/tasks/example-test.sh
@@ -69,16 +69,40 @@ list_example examples/fixtures
 
 # These examples own all of their runtime dependencies. The Python Compose
 # example and the k3d example can run together; only one Compose stack runs at
-# a time because fixture startup prunes Docker networks.
-if ! command -v docker >/dev/null 2>&1; then
-	echo "docker is required for the runtime examples" >&2
+# a time because fixture startup prunes container-engine networks.
+container_runtime="${OATS_CONTAINER_RUNTIME:-auto}"
+case "$container_runtime" in
+auto)
+	if command -v podman >/dev/null 2>&1; then
+		container_engine=podman
+	elif command -v docker >/dev/null 2>&1; then
+		container_engine=docker
+	else
+		echo "podman or docker is required for the runtime examples" >&2
+		exit 1
+	fi
+	;;
+docker | podman)
+	container_engine="$container_runtime"
+	if ! command -v "$container_engine" >/dev/null 2>&1; then
+		echo "$container_engine is required by OATS_CONTAINER_RUNTIME=$container_runtime" >&2
+		exit 1
+	fi
+	;;
+*)
+	echo "unknown OATS_CONTAINER_RUNTIME: $container_runtime (want auto, docker, or podman)" >&2
 	exit 1
-fi
+	;;
+esac
 
-docker pull docker.io/grafana/otel-lgtm:latest
+"$container_engine" pull docker.io/grafana/otel-lgtm:latest
 if [[ "$mode" == compose ]]; then
 	run_example examples/fixtures --tags compose
 else
+	if [[ "$container_engine" != docker ]]; then
+		echo "the k3d example currently requires Docker; use OATS_EXAMPLE_MODE=compose with Podman" >&2
+		exit 1
+	fi
 	if ! command -v k3d >/dev/null 2>&1 || ! command -v kubectl >/dev/null 2>&1; then
 		echo "k3d and kubectl are required for the app examples" >&2
 		exit 1

--- a/README.md
+++ b/README.md
@@ -71,6 +71,11 @@ default to disabled downloads when mise is detected, even outside a mise task.
 You can always select a specific release with
 `--gcx-version <version>` or a binary with `--gcx <path>`.
 
+For Compose fixtures, OATS prefers Podman when it is available and falls back
+to Docker. Use `--container-runtime docker` (or
+`OATS_CONTAINER_RUNTIME=docker`) to make the engine explicit. k3d fixtures
+currently require Docker.
+
 ## Getting started
 
 The recommended starting point is [`examples/python/`](examples/python/): a real,

--- a/docs/case-reference.md
+++ b/docs/case-reference.md
@@ -295,14 +295,15 @@ assuming `/bin/sh` exists. The process runs with its working directory set to
 the case directory and inherits the parent environment plus these OATS-provided
 variables:
 
-| Variable                                                         | Fixtures     | Meaning                                              |
-| ---------------------------------------------------------------- | ------------ | ---------------------------------------------------- |
-| `OATS_FIXTURE_TYPE`                                              | all          | `remote` / `compose` / `k3d`                         |
-| `OATS_GRAFANA_URL`                                               | all          | base URL of the fixture's Grafana                    |
-| `OATS_APP_URL`                                                   | remote, k3d  | base URL of the app under test                       |
-| `OATS_OTLP_HTTP`                                                 | compose, k3d | OTLP/HTTP endpoint                                   |
-| `OATS_PYROSCOPE_URL`                                             | compose, k3d | Pyroscope base URL                                   |
-| `COMPOSE_PROJECT_NAME`, `COMPOSE_FILE`, `OATS_COMPOSE_FILE_ARGS` | compose      | let the script run its own `docker compose` commands |
+| Variable                                                         | Fixtures     | Meaning                                                     |
+| ---------------------------------------------------------------- | ------------ | ----------------------------------------------------------- |
+| `OATS_FIXTURE_TYPE`                                              | all          | `remote` / `compose` / `k3d`                                |
+| `OATS_GRAFANA_URL`                                               | all          | base URL of the fixture's Grafana                           |
+| `OATS_APP_URL`                                                   | remote, k3d  | base URL of the app under test                              |
+| `OATS_OTLP_HTTP`                                                 | compose, k3d | OTLP/HTTP endpoint                                          |
+| `OATS_PYROSCOPE_URL`                                             | compose, k3d | Pyroscope base URL                                          |
+| `OATS_CONTAINER_RUNTIME`                                         | compose      | resolved engine (`docker` or `podman`) for Compose commands |
+| `COMPOSE_PROJECT_NAME`, `COMPOSE_FILE`, `OATS_COMPOSE_FILE_ARGS` | compose      | let the script run its own `<runtime> compose` commands     |
 
 A custom check that queries Grafana directly (replacing, for example, a legacy
 `compose-logs` grep with a real LogQL query):

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -35,6 +35,11 @@ replace hyphens with underscores, and prefix it with `OATS_`. Command-line
 flags take precedence over environment variables. For example,
 `--gcx /opt/tools/gcx` is equivalent to `OATS_GCX=/opt/tools/gcx`.
 
+Compose fixtures use the host container engine selected by
+`--container-runtime` (or `OATS_CONTAINER_RUNTIME`). `auto` prefers Podman and
+falls back to Docker; selecting `podman` or `docker` explicitly never silently
+falls back. k3d fixtures currently require Docker.
+
 Release and mise-built `oats` binaries contain the gcx version pinned by this
 repository. If the default `gcx` command is not on `PATH`, `oats` downloads and
 caches that verified release automatically. Set `--gcx-download never` (or
@@ -61,6 +66,7 @@ Flags:
 | `--gcx-version`             | `OATS_GCX_VERSION`                | —                                                                  | download and use this gcx release (for example, `0.4.3`)                               |
 | `--gcx-download`            | `OATS_GCX_DOWNLOAD`               | `auto` (`never` when mise is detected)                             | fallback policy when the default gcx command is missing: `auto` or `never`             |
 | `--gcx-context`             | `OATS_GCX_CONTEXT`                | derived                                                            | gcx context to query (otherwise derived from the fixture endpoint)                     |
+| `--container-runtime`       | `OATS_CONTAINER_RUNTIME`          | `auto`                                                             | Compose engine: prefer Podman, or explicitly use `docker` / `podman`                   |
 | `--app-host` / `--app-port` | `OATS_APP_HOST` / `OATS_APP_PORT` | `localhost` / `8080`                                               | where to drive `input` requests when a fixture doesn't resolve the app endpoint itself |
 | `--otlp-http`               | `OATS_OTLP_HTTP`                  | `http://localhost:4318`                                            | OTLP/HTTP base URL for the `inline-otlp` seed                                          |
 | `--verbose`                 | `OATS_VERBOSE`                    | `0`                                                                | increase verbosity (`1`–`3` are the useful levels)                                     |

--- a/fixture/compose.go
+++ b/fixture/compose.go
@@ -12,10 +12,10 @@ import (
 	"github.com/grafana/oats/casefile"
 	"github.com/grafana/oats/discovery"
 	"github.com/grafana/oats/testhelpers"
+	"github.com/grafana/oats/testhelpers/container"
 )
 
 const (
-	composeCLIBinary   = "docker"
 	lgtmComposeService = "lgtm"
 )
 
@@ -23,7 +23,7 @@ func portString(port int) string {
 	return strconv.Itoa(port)
 }
 
-func startCompose(plan discovery.Plan) (Handle, Runtime, error) {
+func startCompose(plan discovery.Plan, engine container.Engine) (Handle, Runtime, error) {
 	compose := plan.Fixture.Compose
 	composeFiles, cleanup, err := resolveComposeFiles(plan.FixtureSourceDir, compose)
 	if err != nil {
@@ -32,7 +32,7 @@ func startCompose(plan discovery.Plan) (Handle, Runtime, error) {
 	project := composeProjectName(plan)
 	suiteEnv := append([]string(nil), compose.Env...)
 	suiteEnv = append(suiteEnv, "COMPOSE_PROJECT_NAME="+project)
-	suite, err := newComposeSuite(composeFiles, suiteEnv)
+	suite, err := newComposeSuite(composeFiles, suiteEnv, engine)
 	if err != nil {
 		if cleanup != nil {
 			_ = cleanup()
@@ -53,31 +53,32 @@ func startCompose(plan discovery.Plan) (Handle, Runtime, error) {
 		}
 		return nil, Runtime{}, err
 	}
-	grafanaPort, err := lookupComposePort(composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.GrafanaHTTPPort))
+	grafanaPort, err := lookupComposePort(engine, composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.GrafanaHTTPPort))
 	if err != nil {
 		return fail(err)
 	}
-	otlpPort, err := lookupComposePort(composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.OTLPHTTPPort))
+	otlpPort, err := lookupComposePort(engine, composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.OTLPHTTPPort))
 	if err != nil {
 		return fail(err)
 	}
-	pyroscopePort, err := lookupComposePort(composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.PyroscopeHTTPPort))
+	pyroscopePort, err := lookupComposePort(engine, composeFiles, suiteEnv, lgtmComposeService, portString(testhelpers.PyroscopeHTTPPort))
 	if err != nil {
 		return fail(err)
 	}
 	rt := Runtime{
-		GrafanaURL:     "http://" + testhelpers.LocalhostIPv4 + ":" + grafanaPort,
-		OTLPHTTP:       "http://" + testhelpers.LocalhostIPv4 + ":" + otlpPort,
-		PyroscopeURL:   "http://" + testhelpers.LocalhostIPv4 + ":" + pyroscopePort,
-		ComposeFiles:   composeFiles,
-		ComposeProject: project,
+		GrafanaURL:       "http://" + testhelpers.LocalhostIPv4 + ":" + grafanaPort,
+		OTLPHTTP:         "http://" + testhelpers.LocalhostIPv4 + ":" + otlpPort,
+		PyroscopeURL:     "http://" + testhelpers.LocalhostIPv4 + ":" + pyroscopePort,
+		ComposeFiles:     composeFiles,
+		ComposeProject:   project,
+		ContainerRuntime: string(engine),
 	}
 	// When the fixture manages the app (app_service + app_port), resolve the host
 	// port docker published for it. This lets the app bind an ephemeral host port
 	// (127.0.0.1::<port>) instead of a fixed one, which is what makes app-seed
 	// suites parallel-safe.
 	if plan.Fixture.HasManagedApp() {
-		appPort, portErr := lookupComposePort(composeFiles, suiteEnv, compose.AppService, strconv.Itoa(compose.AppPort))
+		appPort, portErr := lookupComposePort(engine, composeFiles, suiteEnv, compose.AppService, strconv.Itoa(compose.AppPort))
 		if portErr != nil {
 			return fail(fmt.Errorf("resolve app host port for service %q: %w", compose.AppService, portErr))
 		}
@@ -167,6 +168,7 @@ func composeCheckEnv(plan discovery.Plan, rt Runtime) []string {
 	}
 	return []string{
 		"OATS_FIXTURE_TYPE=compose",
+		"OATS_CONTAINER_RUNTIME=" + rt.ContainerRuntime,
 		"COMPOSE_PROJECT_NAME=" + rt.ComposeProject,
 		"COMPOSE_FILE=" + strings.Join(files, string(os.PathListSeparator)),
 		"OATS_COMPOSE_FILE_ARGS=" + composeFileArgs(files),
@@ -300,7 +302,7 @@ func readComposeGrafanaToken(plan discovery.Plan) (string, error) {
 		args = append(args, "-f", f)
 	}
 	args = append(args, "exec", "-T", lgtmComposeService, "sh", "-c", "cat /tmp/grafana-sa-token 2>/dev/null || true")
-	cmd := exec.Command(composeCLIBinary, args...)
+	cmd := exec.Command("docker", args...)
 	cmd.Env = append(cmd.Environ(), compose.Env...)
 	out, err := cmd.Output()
 	if err != nil {
@@ -309,19 +311,19 @@ func readComposeGrafanaToken(plan discovery.Plan) (string, error) {
 	return string(out), nil
 }
 
-func dockerComposePort(files []string, env []string, service, containerPort string) (string, error) {
-	args := []string{"compose"}
+func composePort(engine container.Engine, files []string, env []string, service, containerPort string) (string, error) {
+	args := engine.ComposeArgs()
 	for _, f := range files {
 		args = append(args, "-f", f)
 	}
 	args = append(args, "port", service, containerPort)
-	cmd := exec.Command(composeCLIBinary, args...)
+	cmd := exec.Command(engine.Binary(), args...)
 	cmd.Env = append(cmd.Environ(), env...)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", err
 	}
-	host, port, err := splitDockerHostPort(strings.TrimSpace(string(out)))
+	host, port, err := splitComposeHostPort(strings.TrimSpace(string(out)))
 	if err != nil {
 		return "", err
 	}
@@ -331,7 +333,7 @@ func dockerComposePort(files []string, env []string, service, containerPort stri
 	return port, nil
 }
 
-func splitDockerHostPort(addr string) (string, string, error) {
+func splitComposeHostPort(addr string) (string, string, error) {
 	addr = strings.TrimSpace(addr)
 	if strings.HasPrefix(addr, "[") {
 		end := strings.Index(addr, "]")

--- a/fixture/compose.go
+++ b/fixture/compose.go
@@ -291,18 +291,18 @@ func fixedShortPortMapping(value string) bool {
 	return false
 }
 
-func readComposeGrafanaToken(plan discovery.Plan) (string, error) {
+func readComposeGrafanaToken(plan discovery.Plan, engine container.Engine) (string, error) {
 	compose := plan.Fixture.Compose
 	files, _, err := resolveComposeFiles(plan.FixtureSourceDir, compose)
 	if err != nil {
 		return "", err
 	}
-	args := []string{"compose"}
+	args := engine.ComposeArgs()
 	for _, f := range files {
 		args = append(args, "-f", f)
 	}
 	args = append(args, "exec", "-T", lgtmComposeService, "sh", "-c", "cat /tmp/grafana-sa-token 2>/dev/null || true")
-	cmd := exec.Command("docker", args...)
+	cmd := exec.Command(engine.Binary(), args...)
 	cmd.Env = append(cmd.Environ(), compose.Env...)
 	out, err := cmd.Output()
 	if err != nil {
@@ -328,7 +328,7 @@ func composePort(engine container.Engine, files []string, env []string, service,
 		return "", err
 	}
 	if host == "" || port == "" {
-		return "", fmt.Errorf("invalid docker compose port output %q", strings.TrimSpace(string(out)))
+		return "", fmt.Errorf("invalid compose port output %q", strings.TrimSpace(string(out)))
 	}
 	return port, nil
 }

--- a/fixture/fixture.go
+++ b/fixture/fixture.go
@@ -280,14 +280,14 @@ contexts:
 	return path, nil
 }
 
-func waitForGrafanaTokenImpl(plan discovery.Plan) (string, error) {
+func waitForGrafanaTokenImpl(plan discovery.Plan, engine container.Engine) (string, error) {
 	deadline := time.Now().Add(3 * time.Minute)
 	for time.Now().Before(deadline) {
 		var token string
 		var err error
 		switch plan.Fixture.Kind() {
 		case "compose":
-			token, err = readComposeGrafanaToken(plan)
+			token, err = readComposeGrafanaToken(plan, engine)
 		case "k3d":
 			token, err = readK3DGrafanaToken()
 		default:

--- a/fixture/fixture.go
+++ b/fixture/fixture.go
@@ -17,14 +17,15 @@ import (
 
 	"github.com/grafana/oats/discovery"
 	"github.com/grafana/oats/testhelpers/compose"
+	"github.com/grafana/oats/testhelpers/container"
 	"github.com/grafana/oats/testhelpers/kubernetes"
 	"github.com/grafana/oats/testhelpers/remote"
 )
 
 // Seams overridable in tests.
 var (
-	newComposeSuite = func(files []string, env []string) (Handle, error) {
-		return compose.SuiteFiles(files, env)
+	newComposeSuite = func(files []string, env []string, engine container.Engine) (Handle, error) {
+		return compose.SuiteFilesWithRuntime(files, env, engine)
 	}
 	newKubernetesEndpoint = func(plan discovery.Plan, ports remote.PortsConfig) *remote.Endpoint {
 		sourceDir := plan.FixtureSourceDir
@@ -44,8 +45,15 @@ var (
 		return kubernetes.NewEndpoint("localhost", model, ports, plan.Name, sourceDir)
 	}
 	waitForGrafanaToken = waitForGrafanaTokenImpl
-	lookupComposePort   = dockerComposePort
+	lookupComposePort   = composePort
 )
+
+// Options controls host-side fixture behavior. It intentionally does not
+// appear in the case schema: the same test should run against the user's
+// selected container engine without changing the test definition.
+type Options struct {
+	ContainerRuntime string
+}
 
 // Runtime carries the resolved coordinates of a booted fixture back to the
 // caller: where the backends live, the gcx config to talk to them, the compose
@@ -61,6 +69,7 @@ type Runtime struct {
 	GCXConfig        string
 	ParallelSafe     bool
 	ParallelDisabled string
+	ContainerRuntime string
 }
 
 // Handle is a booted fixture that can be torn down.
@@ -77,11 +86,42 @@ type startableHandle interface {
 // teardown plus the resolved Runtime. Remote/empty fixtures need no boot and
 // return a nil Handle.
 func Start(ctx context.Context, plan discovery.Plan) (Handle, Runtime, error) {
+	return startWithEngine(ctx, plan, container.Docker)
+}
+
+// StartWithOptions boots a fixture using host-side options supplied by the
+// CLI. An empty runtime keeps the Docker compatibility default for library
+// callers; the CLI passes auto so local runs prefer Podman when available.
+func StartWithOptions(ctx context.Context, plan discovery.Plan, opts Options) (Handle, Runtime, error) {
+	engine := opts.ContainerRuntime
+	if engine == "" {
+		engine = string(container.Docker)
+	}
+
+	if plan.Fixture.Kind() == "compose" {
+		resolved, err := container.Resolve(engine)
+		if err != nil {
+			return nil, Runtime{}, err
+		}
+		return startWithEngine(ctx, plan, resolved)
+	}
+
+	requested, err := container.Parse(engine)
+	if err != nil {
+		return nil, Runtime{}, err
+	}
+	if requested == container.Podman {
+		return nil, Runtime{}, fmt.Errorf("k3d fixtures require Docker; Podman is currently supported for Compose fixtures")
+	}
+	return startWithEngine(ctx, plan, container.Docker)
+}
+
+func startWithEngine(ctx context.Context, plan discovery.Plan, engine container.Engine) (Handle, Runtime, error) {
 	switch plan.Fixture.Kind() {
 	case "", "remote":
 		return nil, Runtime{ParallelSafe: true}, nil
 	case "compose":
-		return startCompose(plan)
+		return startCompose(plan, engine)
 	case "k3d":
 		return startK3D(ctx, plan)
 	default:

--- a/fixture/fixture_test.go
+++ b/fixture/fixture_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/grafana/oats/discovery"
 	"github.com/grafana/oats/runner"
 	"github.com/grafana/oats/testhelpers"
+	"github.com/grafana/oats/testhelpers/container"
 	"github.com/grafana/oats/testhelpers/remote"
 )
 
@@ -83,13 +84,15 @@ func TestStart_ComposeLifecycle(t *testing.T) {
 	defer func() { lookupComposePort = oldLookup }()
 
 	var gotFiles, gotEnv []string
+	var gotEngine container.Engine
 	fake := &fakeHandle{}
-	newComposeSuite = func(files []string, env []string) (Handle, error) {
+	newComposeSuite = func(files []string, env []string, engine container.Engine) (Handle, error) {
 		gotFiles = append([]string(nil), files...)
 		gotEnv = append([]string(nil), env...)
+		gotEngine = engine
 		return fake, nil
 	}
-	lookupComposePort = func(files []string, env []string, service, containerPort string) (string, error) {
+	lookupComposePort = func(engine container.Engine, files []string, env []string, service, containerPort string) (string, error) {
 		switch containerPort {
 		case "3000":
 			return "43000", nil
@@ -128,6 +131,9 @@ func TestStart_ComposeLifecycle(t *testing.T) {
 	if len(gotEnv) != 2 || gotEnv[0] != "FOO=bar" || !strings.HasPrefix(gotEnv[1], "COMPOSE_PROJECT_NAME=oats-smoke-") {
 		t.Fatalf("compose env: got %v", gotEnv)
 	}
+	if gotEngine != container.Docker {
+		t.Fatalf("container engine: got %q want %q", gotEngine, container.Docker)
+	}
 	if err := fix.Close(); err != nil {
 		t.Fatalf("fixture close: %v", err)
 	}
@@ -136,11 +142,59 @@ func TestStart_ComposeLifecycle(t *testing.T) {
 	}
 }
 
+func TestStartWithOptions_ComposePodman(t *testing.T) {
+	oldFactory := newComposeSuite
+	oldLookup := lookupComposePort
+	defer func() { newComposeSuite = oldFactory }()
+	defer func() { lookupComposePort = oldLookup }()
+
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "podman"), []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	var gotEngine container.Engine
+	fake := &fakeHandle{}
+	newComposeSuite = func(_ []string, _ []string, engine container.Engine) (Handle, error) {
+		gotEngine = engine
+		return fake, nil
+	}
+	lookupComposePort = func(_ container.Engine, _ []string, _ []string, _ string, port string) (string, error) {
+		switch port {
+		case "3000":
+			return "43000", nil
+		case "4318":
+			return "44318", nil
+		case "4040":
+			return "44040", nil
+		default:
+			return "", fmt.Errorf("unexpected port %s", port)
+		}
+	}
+
+	fix, rt, err := StartWithOptions(context.Background(), discovery.Plan{
+		Name:             "podman-smoke",
+		Fixture:          casefile.FixtureConfig{Compose: &casefile.ComposeFixture{Template: "none", File: "compose.yml"}},
+		FixtureSourceDir: t.TempDir(),
+	}, Options{ContainerRuntime: "podman"})
+	if err != nil {
+		t.Fatalf("StartWithOptions: %v", err)
+	}
+	defer func() { _ = fix.Close() }()
+	if gotEngine != container.Podman || rt.ContainerRuntime != string(container.Podman) {
+		t.Fatalf("engine: factory=%q runtime=%q", gotEngine, rt.ContainerRuntime)
+	}
+	if !containsString(rt.CustomCheckEnv, "OATS_CONTAINER_RUNTIME=podman") {
+		t.Fatalf("custom check env missing Podman runtime: %v", rt.CustomCheckEnv)
+	}
+}
+
 func TestStart_ComposeStartFailure(t *testing.T) {
 	oldFactory := newComposeSuite
 	defer func() { newComposeSuite = oldFactory }()
 
-	newComposeSuite = func(files []string, env []string) (Handle, error) {
+	newComposeSuite = func(files []string, env []string, engine container.Engine) (Handle, error) {
 		return &fakeHandle{upErr: fmt.Errorf("boom")}, nil
 	}
 

--- a/fixture/fixture_test.go
+++ b/fixture/fixture_test.go
@@ -435,7 +435,7 @@ func TestSupportsParallel_AppSeedRequiresAppService(t *testing.T) {
 func TestWaitForGrafanaToken_DefaultFixtureReturnsEmpty(t *testing.T) {
 	token, err := waitForGrafanaToken(discovery.Plan{
 		Fixture: casefile.FixtureConfig{Remote: &casefile.RemoteFixture{}},
-	})
+	}, container.Docker)
 	if err != nil {
 		t.Fatalf("waitForGrafanaToken: %v", err)
 	}

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -52,6 +52,7 @@ import (
 	"github.com/grafana/oats/report"
 	"github.com/grafana/oats/runner"
 	"github.com/grafana/oats/testhelpers"
+	"github.com/grafana/oats/testhelpers/container"
 )
 
 // Version is the oats CLI version. Release builds can override this with
@@ -138,6 +139,7 @@ func addRunFlags(fs *pflag.FlagSet) {
 	fs.Duration("absent-timeout", 10*time.Second, "how long an absent assertion must stay absent")
 	fs.Duration("seed-settle", 2*time.Second, "post-seed wait before first assertion")
 	fs.String("gcx-context", "", "override the gcx --context value (otherwise derived from fixture endpoint)")
+	fs.String("container-runtime", "auto", "container engine for Compose fixtures: auto | docker | podman")
 	fs.String("app-host", "localhost", "application host for driving case input requests")
 	fs.Int("app-port", 8080, "application port for driving case input requests")
 	fs.String("otlp-http", defaultOTLPHTTP(), "OTLP/HTTP base URL for inline-otlp seed mode")
@@ -366,6 +368,10 @@ func runAction(cmd *cobra.Command, args []string, verbose int, exit *int) error 
 	defer cancel()
 
 	gcxBin := flagStr(fs, "gcx")
+	containerRuntime := flagStr(fs, "container-runtime")
+	if _, err := container.Parse(containerRuntime); err != nil {
+		return err
+	}
 	if version := flagStr(fs, "gcx-version"); version != "" {
 		if fs.Changed("gcx") {
 			return fmt.Errorf("--gcx and --gcx-version cannot be used together")
@@ -385,6 +391,7 @@ func runAction(cmd *cobra.Command, args []string, verbose int, exit *int) error 
 	opts := runOptions{
 		gcxBin:             gcxBin,
 		gcxContextOverride: flagStr(fs, "gcx-context"),
+		containerRuntime:   containerRuntime,
 		appHost:            flagStr(fs, "app-host"),
 		appPort:            flagInt(fs, "app-port"),
 		otlpHTTP:           flagStr(fs, "otlp-http"),
@@ -499,6 +506,7 @@ func resolveEndpoint(plan discovery.Plan, rt fixture.Runtime, gcxContextOverride
 type runOptions struct {
 	gcxBin             string
 	gcxContextOverride string
+	containerRuntime   string
 	appHost            string
 	appPort            int
 	otlpHTTP           string
@@ -616,7 +624,7 @@ func runPlansParallel(parent context.Context, rep report.Reporter, plans []disco
 
 func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts runOptions) suiteResult {
 	fixtureStart := emitFixtureStart(rep, plan)
-	fix, rt, err := fixture.Start(ctx, plan)
+	fix, rt, err := fixture.StartWithOptions(ctx, plan, fixture.Options{ContainerRuntime: opts.containerRuntime})
 	if err != nil {
 		return suiteResult{err: fmt.Errorf("suite %q: %w", plan.Name, err)}
 	}

--- a/runner/checks.go
+++ b/runner/checks.go
@@ -14,6 +14,7 @@ import (
 	"github.com/grafana/oats/assert"
 	"github.com/grafana/oats/casefile"
 	"github.com/grafana/oats/report"
+	"github.com/grafana/oats/testhelpers/container"
 	"github.com/grafana/oats/wait"
 )
 
@@ -130,13 +131,27 @@ func searchComposeLogs(ctx context.Context, extraEnv []string, needle string) (b
 	if envValue(extraEnv, "OATS_FIXTURE_TYPE") != "compose" {
 		return false, fmt.Errorf("compose-logs requires a compose fixture")
 	}
-	cmd := exec.CommandContext(ctx, "docker", "compose", "logs", "--no-color")
+	engine := container.Docker
+	if raw := envValue(extraEnv, "OATS_CONTAINER_RUNTIME"); raw != "" {
+		parsed, err := container.Parse(raw)
+		if err != nil {
+			return false, err
+		}
+		if parsed == container.Auto {
+			parsed, err = container.Resolve(raw)
+			if err != nil {
+				return false, err
+			}
+		}
+		engine = parsed
+	}
+	cmd := exec.CommandContext(ctx, engine.Binary(), engine.ComposeArgs("logs", "--no-color")...)
 	cmd.Env = append(cmd.Environ(), extraEnv...)
 	var out bytes.Buffer
 	cmd.Stdout = &out
 	cmd.Stderr = &out
 	if err := cmd.Run(); err != nil {
-		return false, fmt.Errorf("docker compose logs: %w\n%s", err, trimOutput(out.String()))
+		return false, fmt.Errorf("%s compose logs: %w\n%s", engine, err, trimOutput(out.String()))
 	}
 	return strings.Contains(out.String(), needle), nil
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -424,6 +424,26 @@ expected:
 	}
 }
 
+func TestSearchComposeLogs_UsesPodman(t *testing.T) {
+	dir := t.TempDir()
+	podman := filepath.Join(dir, "podman")
+	if err := os.WriteFile(podman, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\"; echo 'podman service started'\n"), 0o755); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	ok, err := searchComposeLogs(context.Background(), []string{
+		"OATS_FIXTURE_TYPE=compose",
+		"OATS_CONTAINER_RUNTIME=podman",
+	}, "podman service started")
+	if err != nil {
+		t.Fatalf("searchComposeLogs: %v", err)
+	}
+	if !ok {
+		t.Fatal("searchComposeLogs returned false")
+	}
+}
+
 func TestRunCase_ComposeLogsMissingSurfaced(t *testing.T) {
 	dir := t.TempDir()
 	binDir := filepath.Join(dir, "bin")

--- a/testhelpers/compose/compose.go
+++ b/testhelpers/compose/compose.go
@@ -1,4 +1,4 @@
-// Package docker provides some helpers to manage docker-compose clusters from the test suites
+// Package compose provides helpers to manage Compose clusters from test suites.
 package compose
 
 import (
@@ -13,6 +13,7 @@ import (
 	"strings"
 	"sync"
 
+	"github.com/grafana/oats/testhelpers/container"
 	"github.com/grafana/oats/testhelpers/remote"
 )
 
@@ -22,8 +23,6 @@ type Compose struct {
 	Paths       []string
 	Env         []string
 }
-
-const composeCLIBinary = "docker"
 
 var dockerPruneMutex sync.Mutex
 
@@ -57,7 +56,17 @@ func Suite(composeFile string) (*Compose, error) {
 }
 
 func SuiteFiles(composeFiles []string, env []string) (*Compose, error) {
-	defaultArgs := []string{"compose"}
+	return SuiteFilesWithRuntime(composeFiles, env, container.Docker)
+}
+
+// SuiteFilesWithRuntime creates a Compose lifecycle using the selected host
+// container engine. Docker remains the compatibility default for callers that
+// use the older SuiteFiles helper.
+func SuiteFilesWithRuntime(composeFiles []string, env []string, engine container.Engine) (*Compose, error) {
+	if engine != container.Docker && engine != container.Podman {
+		return nil, fmt.Errorf("unsupported container runtime %q for Compose", engine)
+	}
+	defaultArgs := engine.ComposeArgs()
 	for _, file := range composeFiles {
 		defaultArgs = append(defaultArgs, "-f", file)
 	}
@@ -67,7 +76,7 @@ func SuiteFiles(composeFiles []string, env []string) (*Compose, error) {
 	}
 	mergedEnv := mergeEnv(defaultEnv(), env)
 	return &Compose{
-		Command:     composeCLIBinary,
+		Command:     engine.Binary(),
 		DefaultArgs: defaultArgs,
 		Paths:       composeFiles,
 		Env:         mergedEnv,
@@ -113,7 +122,7 @@ func (c *Compose) runDocker(cc command) error {
 	if cc.logConsumer != nil {
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
-			return fmt.Errorf("failed to open docker stdout pipe: %w", err)
+			return fmt.Errorf("failed to open compose stdout pipe: %w", err)
 		}
 		cmd.Stderr = cmd.Stdout
 		// Start before spawning the consumer: if Start fails the write end of
@@ -121,20 +130,20 @@ func (c *Compose) runDocker(cc command) error {
 		// the read forever and leak.
 		if err := cmd.Start(); err != nil {
 			_ = stdout.Close()
-			return fmt.Errorf("failed to start docker command: %w", err)
+			return fmt.Errorf("failed to start compose command: %w", err)
 		}
 		wg := sync.WaitGroup{}
 		wg.Add(1)
 		go cc.logConsumer(stdout, &wg)
 		wg.Wait()
 		if err := cmd.Wait(); err != nil {
-			return fmt.Errorf("failed to run docker command: %w", err)
+			return fmt.Errorf("failed to run compose command: %w", err)
 		}
 	} else if cc.background {
 		slog.Info("Running", "command", cmd.String(), "compose_files", c.Paths)
 		stdout, err := cmd.StdoutPipe()
 		if err != nil {
-			return fmt.Errorf("failed to open docker stdout pipe: %w", err)
+			return fmt.Errorf("failed to open compose stdout pipe: %w", err)
 		}
 		cmd.Stderr = cmd.Stdout
 		// Start the command before spawning the reader: if Start fails the
@@ -142,7 +151,7 @@ func (c *Compose) runDocker(cc command) error {
 		// block forever on ReadString and leak.
 		if err := cmd.Start(); err != nil {
 			_ = stdout.Close()
-			return fmt.Errorf("failed to start docker command: %w", err)
+			return fmt.Errorf("failed to start compose command: %w", err)
 		}
 		wg := sync.WaitGroup{}
 		wg.Add(1)
@@ -167,7 +176,7 @@ func (c *Compose) runDocker(cc command) error {
 		err = cmd.Wait()
 		wg.Wait()
 		if err != nil {
-			return fmt.Errorf("failed to run docker command: %w", err)
+			return fmt.Errorf("failed to run compose command: %w", err)
 		}
 	} else {
 		slog.Info("Running", "command", cmd.String(), "compose_files", c.Paths)
@@ -175,7 +184,7 @@ func (c *Compose) runDocker(cc command) error {
 		cmd.Stderr = os.Stderr
 		err := cmd.Run()
 		if err != nil {
-			return fmt.Errorf("failed to run docker command: %w", err)
+			return fmt.Errorf("failed to run compose command: %w", err)
 		}
 	}
 	return nil
@@ -199,6 +208,13 @@ func (c *Compose) Close() error {
 }
 
 func NewEndpoint(host string, composeFilePath string, ports remote.PortsConfig) *remote.Endpoint {
+	return NewEndpointWithRuntime(host, composeFilePath, ports, container.Docker)
+}
+
+// NewEndpointWithRuntime creates the legacy remote endpoint wrapper using a
+// selected Compose engine. New fixture code should prefer SuiteFilesWithRuntime
+// directly.
+func NewEndpointWithRuntime(host string, composeFilePath string, ports remote.PortsConfig, engine container.Engine) *remote.Endpoint {
 	var compose *Compose
 	return remote.NewEndpoint(host, ports, func(ctx context.Context) error {
 		var err error
@@ -207,7 +223,7 @@ func NewEndpoint(host string, composeFilePath string, ports remote.PortsConfig) 
 			return fmt.Errorf("composeFilePath cannot be empty")
 		}
 
-		compose, err = Suite(composeFilePath)
+		compose, err = SuiteFilesWithRuntime([]string{composeFilePath}, nil, engine)
 		if err != nil {
 			return err
 		}

--- a/testhelpers/container/container.go
+++ b/testhelpers/container/container.go
@@ -1,0 +1,90 @@
+// Package container describes the host container engine used by fixture
+// adapters. It intentionally does not own Compose or Kubernetes lifecycle;
+// those are separate adapters with different capabilities.
+package container
+
+import (
+	"fmt"
+	"os/exec"
+	"strings"
+)
+
+// Engine is a supported host container engine.
+type Engine string
+
+const (
+	// Auto prefers Podman and falls back to Docker when the user did not select
+	// an engine explicitly.
+	Auto   Engine = "auto"
+	Docker Engine = "docker"
+	Podman Engine = "podman"
+)
+
+// Parse validates a requested engine name. An empty value means Auto.
+func Parse(value string) (Engine, error) {
+	switch strings.ToLower(strings.TrimSpace(value)) {
+	case "", string(Auto):
+		return Auto, nil
+	case string(Docker):
+		return Docker, nil
+	case string(Podman):
+		return Podman, nil
+	default:
+		return "", fmt.Errorf("unsupported container runtime %q (want auto, docker, or podman)", value)
+	}
+}
+
+// Resolve selects an installed engine. Explicit selections are never silently
+// replaced by another engine; Auto is the only policy that falls back.
+func Resolve(value string) (Engine, error) {
+	requested, err := Parse(value)
+	if err != nil {
+		return "", err
+	}
+	if requested != Auto {
+		if err := available(requested); err != nil {
+			return "", fmt.Errorf("container runtime %s is not available: %w", requested, err)
+		}
+		return requested, nil
+	}
+	for _, candidate := range []Engine{Podman, Docker} {
+		if available(candidate) == nil {
+			return candidate, nil
+		}
+	}
+	return "", fmt.Errorf("no supported container runtime found on PATH (tried podman, docker)")
+}
+
+func available(engine Engine) error {
+	if _, err := exec.LookPath(engine.Binary()); err != nil {
+		return err
+	}
+	if engine == Podman {
+		// podman compose delegates to an external provider. Probe it during
+		// auto-selection so an installed Podman without podman-compose (or a
+		// configured provider) falls back to Docker instead of failing later.
+		if err := exec.Command(engine.Binary(), "compose", "version").Run(); err != nil {
+			return fmt.Errorf("compose provider unavailable: %w", err)
+		}
+	}
+	return nil
+}
+
+// Binary returns the executable used by the engine.
+func (e Engine) Binary() string {
+	switch e {
+	case Podman:
+		return "podman"
+	case Docker:
+		return "docker"
+	default:
+		return ""
+	}
+}
+
+// ComposeArgs prefixes args with the Compose subcommand used by Docker and
+// Podman. Podman delegates Compose to a provider, so provider compatibility is
+// checked by the fixture startup rather than assumed here.
+func (e Engine) ComposeArgs(args ...string) []string {
+	return append([]string{"compose"}, args...)
+}

--- a/testhelpers/container/container.go
+++ b/testhelpers/container/container.go
@@ -47,7 +47,7 @@ func Resolve(value string) (Engine, error) {
 		}
 		return requested, nil
 	}
-	// Try engines in preference order: Podman first, then Docker.
+	// Try engines in preference order.
 	for _, candidate := range []Engine{Podman, Docker} {
 		if available(candidate) == nil {
 			return candidate, nil

--- a/testhelpers/container/container_test.go
+++ b/testhelpers/container/container_test.go
@@ -1,0 +1,95 @@
+package container
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+func TestParse(t *testing.T) {
+	tests := []struct {
+		name  string
+		value string
+		want  Engine
+	}{
+		{name: "empty", want: Auto},
+		{name: "auto", value: "AUTO", want: Auto},
+		{name: "docker", value: " docker ", want: Docker},
+		{name: "podman", value: "Podman", want: Podman},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := Parse(tt.value)
+			if err != nil {
+				t.Fatalf("Parse(%q): %v", tt.value, err)
+			}
+			if got != tt.want {
+				t.Fatalf("Parse(%q) = %q, want %q", tt.value, got, tt.want)
+			}
+		})
+	}
+
+	if _, err := Parse("containerd"); err == nil {
+		t.Fatal("Parse(containerd) unexpectedly succeeded")
+	}
+}
+
+func TestComposeArgs(t *testing.T) {
+	for _, engine := range []Engine{Docker, Podman} {
+		got := engine.ComposeArgs("-f", "compose.yml", "up")
+		want := []string{"compose", "-f", "compose.yml", "up"}
+		if len(got) != len(want) {
+			t.Fatalf("%s args = %v, want %v", engine, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Fatalf("%s args = %v, want %v", engine, got, want)
+			}
+		}
+	}
+}
+
+func TestResolveExplicitDoesNotFallback(t *testing.T) {
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX executable")
+	}
+	path := filepath.Join(dir, "podman")
+	if err := os.WriteFile(path, []byte("#!/bin/sh\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := Resolve("podman")
+	if err != nil {
+		t.Fatalf("Resolve(podman): %v", err)
+	}
+	if got != Podman {
+		t.Fatalf("Resolve(podman) = %q, want %q", got, Podman)
+	}
+	if _, err := Resolve("docker"); err == nil {
+		t.Fatal("Resolve(docker) unexpectedly fell back to podman")
+	}
+}
+
+func TestResolveAutoPrefersPodman(t *testing.T) {
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses POSIX executables")
+	}
+	for _, name := range []string{"podman", "docker"} {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte("#!/bin/sh\n"), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := Resolve("auto")
+	if err != nil {
+		t.Fatalf("Resolve(auto): %v", err)
+	}
+	if got != Podman {
+		t.Fatalf("Resolve(auto) = %q, want %q", got, Podman)
+	}
+}

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -14,6 +14,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/grafana/oats/testhelpers/container"
 	"go.yaml.in/yaml/v3"
 )
 
@@ -54,15 +55,16 @@ type placeholders struct {
 }
 
 type sharedEnv struct {
-	RepoRoot       string
-	TempDir        string
-	ComposeFile    string
-	Project        string
-	GrafanaURL     string
-	RemoteOTLPHTTP string
-	GCX            string
-	GCXConfig      string
-	OATS           string
+	RepoRoot         string
+	TempDir          string
+	ComposeFile      string
+	Project          string
+	GrafanaURL       string
+	RemoteOTLPHTTP   string
+	GCX              string
+	GCXConfig        string
+	OATS             string
+	ContainerRuntime string
 }
 
 var (
@@ -121,8 +123,12 @@ func TestCases(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("e2e cases rely on POSIX shell helpers")
 	}
-	if _, err := exec.LookPath("docker"); err != nil {
-		t.Skip("docker is required for e2e")
+	engine, err := container.Resolve(os.Getenv("OATS_CONTAINER_RUNTIME"))
+	if err != nil {
+		t.Skipf("container runtime is required for e2e: %v", err)
+	}
+	if engine == container.Podman && strings.Contains(os.Getenv("OATS_E2E_FILTER"), "k3d") {
+		t.Skip("k3d e2e cases require Docker; run the Compose shard for Podman")
 	}
 
 	root := repoRoot(t)
@@ -166,13 +172,15 @@ func TestCases(t *testing.T) {
 func setupSharedEnv(env *sharedEnv) error {
 	start := time.Now()
 	fmt.Fprintln(os.Stderr, "e2e timing: setting up shared remote LGTM env")
-	if _, err := exec.LookPath("docker"); err != nil {
+	engine, err := container.Resolve(os.Getenv("OATS_CONTAINER_RUNTIME"))
+	if err != nil {
 		return err
 	}
 	if err := prepareLocalTools(env); err != nil {
 		return err
 	}
 	env.Project = fmt.Sprintf("oatse2e%d", os.Getpid())
+	env.ContainerRuntime = string(engine)
 	env.ComposeFile = filepath.Join(env.TempDir, "docker-compose.yml")
 	const composeBody = `services:
   lgtm:
@@ -184,19 +192,20 @@ func setupSharedEnv(env *sharedEnv) error {
 	if err := os.WriteFile(env.ComposeFile, []byte(composeBody), 0o644); err != nil {
 		return err
 	}
-	up := exec.Command("docker", "compose", "-p", env.Project, "-f", env.ComposeFile, "up", "-d")
+	upArgs := append(engine.ComposeArgs(), "-p", env.Project, "-f", env.ComposeFile, "up", "-d")
+	up := exec.Command(engine.Binary(), upArgs...)
 	up.Stdout = os.Stdout
 	up.Stderr = os.Stderr
 	upStart := time.Now()
 	if err := up.Run(); err != nil {
 		return fmt.Errorf("start shared lgtm: %w", err)
 	}
-	fmt.Fprintf(os.Stderr, "e2e timing: docker compose up for shared LGTM finished in %s\n", time.Since(upStart).Round(time.Millisecond))
-	grafanaPort, err := dockerComposePort(env.Project, env.ComposeFile, "lgtm", "3000")
+	fmt.Fprintf(os.Stderr, "e2e timing: %s compose up for shared LGTM finished in %s\n", engine, time.Since(upStart).Round(time.Millisecond))
+	grafanaPort, err := dockerComposePort(engine, env.Project, env.ComposeFile, "lgtm", "3000")
 	if err != nil {
 		return err
 	}
-	otlpPort, err := dockerComposePort(env.Project, env.ComposeFile, "lgtm", "4318")
+	otlpPort, err := dockerComposePort(engine, env.Project, env.ComposeFile, "lgtm", "4318")
 	if err != nil {
 		return err
 	}
@@ -320,24 +329,25 @@ func writeGCXConfig(path, grafanaURL string) error {
 	return os.WriteFile(path, data, 0o600)
 }
 
-func dockerComposePort(project, composeFile, service, containerPort string) (string, error) {
-	cmd := exec.Command("docker", "compose", "-p", project, "-f", composeFile, "port", service, containerPort)
+func dockerComposePort(engine container.Engine, project, composeFile, service, containerPort string) (string, error) {
+	args := append(engine.ComposeArgs(), "-p", project, "-f", composeFile, "port", service, containerPort)
+	cmd := exec.Command(engine.Binary(), args...)
 	var stdout, stderr bytes.Buffer
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
-		return "", fmt.Errorf("docker compose port %s %s: %w\n%s", service, containerPort, err, stderr.String())
+		return "", fmt.Errorf("%s compose port %s %s: %w\n%s", engine, service, containerPort, err, stderr.String())
 	}
 	out := strings.TrimSpace(stdout.String())
 	if out == "" {
-		return "", fmt.Errorf("docker compose port %s %s: empty output", service, containerPort)
+		return "", fmt.Errorf("%s compose port %s %s: empty output", engine, service, containerPort)
 	}
 	host, port, err := splitHostPort(out)
 	if err != nil {
-		return "", fmt.Errorf("docker compose port %s %s: %w", service, containerPort, err)
+		return "", fmt.Errorf("%s compose port %s %s: %w", engine, service, containerPort, err)
 	}
 	if host == "" {
-		return "", fmt.Errorf("docker compose port %s %s: missing host in %q", service, containerPort, out)
+		return "", fmt.Errorf("%s compose port %s %s: missing host in %q", engine, service, containerPort, out)
 	}
 	return port, nil
 }
@@ -361,7 +371,9 @@ func splitHostPort(addr string) (string, string, error) {
 func teardownSharedEnv(env *sharedEnv) error {
 	var errs []string
 	if env.ComposeFile != "" {
-		cmd := exec.Command("docker", "compose", "-p", env.Project, "-f", env.ComposeFile, "down", "-v", "--remove-orphans")
+		engine := container.Engine(env.ContainerRuntime)
+		args := append(engine.ComposeArgs(), "-p", env.Project, "-f", env.ComposeFile, "down", "-v", "--remove-orphans")
+		cmd := exec.Command(engine.Binary(), args...)
 		cmd.Stdout = os.Stdout
 		cmd.Stderr = os.Stderr
 		if err := cmd.Run(); err != nil {


### PR DESCRIPTION
## Summary

- add a host container-engine selector with Podman-first `auto` behavior
- route Compose lifecycle, port lookup, compose-log assertions, and e2e harness setup through the selected engine
- support explicit `OATS_CONTAINER_RUNTIME=docker|podman|auto` and `--container-runtime`
- add rootless Podman Compose CI coverage while keeping k3d on Docker

## Why

Fixture lifecycle code previously assumed `docker` in several places, including Compose port lookup and `compose-logs` assertions. That prevented users from running Compose-backed OATS cases with Podman and made the existing fixture abstraction incomplete.

The case schema remains engine-neutral. Explicit engine selection never falls back; `auto` prefers Podman and falls back to Docker. k3d is kept as a separate Docker-backed workflow until it has reliable Podman coverage.

## Validation

- `mise run lint`
- `GOFLAGS=-buildvcs=false go test ./...`
- signed commit

CI adds both Docker and Podman Compose example/e2e paths; Podman availability is required to validate the live adapter.
