### PR TITLE
chore: move mise task implementations to file tasks

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         run: mise run build
       - name: Run tests
-        run: COVERAGE_PROFILE=coverage.out mise run test
+        run: mise run test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,7 +27,7 @@ jobs:
       - name: Build
         run: mise run build
       - name: Run tests
-        run: mise run test
+        run: COVERAGE_PROFILE=coverage.out mise run test
       - name: Upload coverage to Codecov
         uses: codecov/codecov-action@fb8b3582c8e4def4969c97caa2f19720cb33a72f # v7.0.0
         with:

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -26,7 +26,7 @@ jobs:
           restore-keys: |
             oats-go-e2e-${{ runner.os }}-${{ runner.arch }}-
       - name: Build e2e tools
-        run: bash ./scripts/build-local-tools.sh "$PWD/.e2e-tools/bin"
+        run: mise run build-local-tools -- "$PWD/.e2e-tools/bin"
       - name: Upload e2e tools
         uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:

--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,6 @@ build/
 *.exe
 dist/
 
-# Locally built binaries (scripts/build-local-tools.sh, mise run example-test)
+# Locally built binaries (mise run build-local-tools, mise run example-test)
 /bin/
 /.e2e-tools/

--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -5,7 +5,7 @@
 set -euo pipefail
 
 root="${MISE_PROJECT_ROOT:?MISE_PROJECT_ROOT must be set by mise}"
-output="${usage_output:-$root/oats}"
+output="${usage_output:-${1:-$root/oats}}"
 gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 
 mkdir -p "$(dirname "$output")"

--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 #MISE description="Build the project"
+#USAGE arg "[output]" help="Output binary path"
 
 set -euo pipefail
 
 root="${MISE_PROJECT_ROOT:?MISE_PROJECT_ROOT must be set by mise}"
-output="${1:-$root/oats}"
+output="${usage_output:-$root/oats}"
 gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 
 mkdir -p "$(dirname "$output")"

--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-root="$(cd "$(dirname "$0")/../.." && pwd)"
+root="${MISE_PROJECT_ROOT:?MISE_PROJECT_ROOT must be set by mise}"
 output="${1:-$root/oats}"
 gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 

--- a/.mise/tasks/build
+++ b/.mise/tasks/build
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
+#MISE description="Build the project"
+
 set -euo pipefail
 
-root="$(cd "$(dirname "$0")/.." && pwd)"
+root="$(cd "$(dirname "$0")/../.." && pwd)"
 output="${1:-$root/oats}"
 gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 

--- a/.mise/tasks/build-local-tools
+++ b/.mise/tasks/build-local-tools
@@ -1,16 +1,18 @@
 #!/usr/bin/env bash
+#MISE description="Build local OATs and gcx tools"
+#USAGE arg "[bin_dir]" help="Output directory for local tools"
 set -euo pipefail
 
-root="$(cd "$(dirname "$0")/.." && pwd)"
-bin_dir="${1:-$root/bin}"
+root="${MISE_PROJECT_ROOT:?MISE_PROJECT_ROOT must be set by mise}"
+bin_dir="${usage_bin_dir:-${1:-$root/bin}}"
 mkdir -p "$bin_dir"
 
-mise -C "$root" run build -- "$bin_dir/oats"
+mise run build -- "$bin_dir/oats"
 
 # CI and mise-based development already have the pinned gcx binary installed.
 # Reuse it instead of downloading and rebuilding a second copy.
 gcx_bin=""
-gcx_bin=$(mise -C "$root" which gcx 2>/dev/null || true)
+gcx_bin=$(mise which gcx 2>/dev/null || true)
 if [[ -n "$gcx_bin" && -x "$gcx_bin" ]]; then
 	install -m 0755 "$gcx_bin" "$bin_dir/gcx"
 else

--- a/.mise/tasks/example-test
+++ b/.mise/tasks/example-test
@@ -18,7 +18,7 @@ all | apps | compose)
 esac
 
 if [[ ! -x "$oats_bin" ]]; then
-	mise run build -- "$oats_bin"
+	mise -C "$root" run build -- "$oats_bin"
 fi
 
 if ! command -v "$gcx_bin" >/dev/null 2>&1; then

--- a/.mise/tasks/example-test
+++ b/.mise/tasks/example-test
@@ -18,7 +18,7 @@ all | apps | compose)
 esac
 
 if [[ ! -x "$oats_bin" ]]; then
-	bash "$root/scripts/build-oats.sh" "$oats_bin"
+	bash "$root/.mise/tasks/build" "$oats_bin"
 fi
 
 if ! command -v "$gcx_bin" >/dev/null 2>&1; then

--- a/.mise/tasks/example-test
+++ b/.mise/tasks/example-test
@@ -3,7 +3,7 @@
 
 set -euo pipefail
 
-root=$(git rev-parse --show-toplevel)
+root="${MISE_PROJECT_ROOT:?MISE_PROJECT_ROOT must be set by mise}"
 oats_bin="${OATS_BIN:-$root/oats}"
 gcx_bin="${GCX_BIN:-gcx}"
 mode="${OATS_EXAMPLE_MODE:-all}"

--- a/.mise/tasks/example-test
+++ b/.mise/tasks/example-test
@@ -18,7 +18,7 @@ all | apps | compose)
 esac
 
 if [[ ! -x "$oats_bin" ]]; then
-	bash "$root/.mise/tasks/build" "$oats_bin"
+	mise -C "$root" run build -- "$oats_bin"
 fi
 
 if ! command -v "$gcx_bin" >/dev/null 2>&1; then

--- a/.mise/tasks/example-test
+++ b/.mise/tasks/example-test
@@ -18,7 +18,7 @@ all | apps | compose)
 esac
 
 if [[ ! -x "$oats_bin" ]]; then
-	mise -C "$root" run build -- "$oats_bin"
+	mise run build -- "$oats_bin"
 fi
 
 if ! command -v "$gcx_bin" >/dev/null 2>&1; then

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -4,13 +4,7 @@
 set -euo pipefail
 
 readonly minimum_coverage="${OATS_MIN_COVERAGE:-80.0}"
-readonly profile="${COVERAGE_PROFILE:-$(mktemp "${TMPDIR:-/tmp}/oats-coverage.XXXXXX")}"
-cleanup() {
-	if [[ -z "${COVERAGE_PROFILE:-}" ]]; then
-		rm -f "$profile"
-	fi
-}
-trap cleanup EXIT
+readonly profile="${COVERAGE_PROFILE:-coverage.out}"
 
 if ! package_list="$(
 		GOFLAGS=-buildvcs=false go list ./... |

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,9 +1,8 @@
 #!/usr/bin/env bash
-#MISE description="Run tests with coverage enforcement"
+#MISE description="Run tests with coverage"
 
 set -euo pipefail
 
-readonly minimum_coverage="${OATS_MIN_COVERAGE:-80.0}"
 readonly profile="${COVERAGE_PROFILE:-coverage.out}"
 
 if ! package_list="$(
@@ -23,13 +22,3 @@ while IFS= read -r pkg; do
 done <<< "$package_list"
 
 GOFLAGS=-buildvcs=false go test -coverprofile="$profile" "${packages[@]}"
-
-coverage="$(go tool cover -func="$profile" | awk '$1 == "total:" {gsub("%", "", $3); print $3}')"
-if [[ -z "$coverage" ]]; then
-	echo "could not determine total test coverage" >&2
-	exit 1
-fi
-
-printf 'total coverage: %s%% (minimum: %s%%)\n' "$coverage" "$minimum_coverage"
-awk -v coverage="$coverage" -v minimum="$minimum_coverage" \
-	'BEGIN { if ((coverage + 0) < (minimum + 0)) { exit 1 } }'

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -4,7 +4,6 @@
 
 set -euo pipefail
 
-: "${MISE_PROJECT_ROOT:?MISE_PROJECT_ROOT must be set by mise}"
 readonly profile="$usage_profile"
 
 if ! package_list="$(

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -4,6 +4,7 @@
 
 set -euo pipefail
 
+: "${MISE_PROJECT_ROOT:?MISE_PROJECT_ROOT must be set by mise}"
 readonly profile="$usage_profile"
 
 if ! package_list="$(

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,0 +1,39 @@
+#!/usr/bin/env bash
+#MISE description="Run tests with coverage enforcement"
+
+set -euo pipefail
+
+readonly minimum_coverage="${OATS_MIN_COVERAGE:-80.0}"
+readonly profile="${COVERAGE_PROFILE:-$(mktemp)}"
+
+cleanup() {
+	if [[ -z "${COVERAGE_PROFILE:-}" ]]; then
+		rm -f "$profile"
+	fi
+}
+trap cleanup EXIT
+
+if ! package_list="$(
+		GOFLAGS=-buildvcs=false go list ./... |
+			awk '$0 != "github.com/grafana/oats/tests/e2e" && index($0, "github.com/grafana/oats/tests/e2e/") != 1'
+)"; then
+	echo "could not discover test packages with go list" >&2
+	exit 1
+fi
+if [[ -z "$package_list" ]]; then
+	echo "could not find packages to test" >&2
+	exit 1
+fi
+mapfile -t packages <<< "$package_list"
+
+GOFLAGS=-buildvcs=false go test -coverprofile="$profile" "${packages[@]}"
+
+coverage="$(go tool cover -func="$profile" | awk '$1 == "total:" {gsub("%", "", $3); print $3}')"
+if [[ -z "$coverage" ]]; then
+	echo "could not determine total test coverage" >&2
+	exit 1
+fi
+
+printf 'total coverage: %s%% (minimum: %s%%)\n' "$coverage" "$minimum_coverage"
+awk -v coverage="$coverage" -v minimum="$minimum_coverage" \
+	'BEGIN { if ((coverage + 0) < (minimum + 0)) { exit 1 } }'

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -1,9 +1,10 @@
 #!/usr/bin/env bash
 #MISE description="Run tests with coverage"
+#USAGE arg "[profile]" env="COVERAGE_PROFILE" default="coverage.out" help="Coverage profile path"
 
 set -euo pipefail
 
-readonly profile="${COVERAGE_PROFILE:-coverage.out}"
+readonly profile="$usage_profile"
 
 if ! package_list="$(
 		GOFLAGS=-buildvcs=false go list ./... |

--- a/.mise/tasks/test
+++ b/.mise/tasks/test
@@ -4,8 +4,7 @@
 set -euo pipefail
 
 readonly minimum_coverage="${OATS_MIN_COVERAGE:-80.0}"
-readonly profile="${COVERAGE_PROFILE:-$(mktemp)}"
-
+readonly profile="${COVERAGE_PROFILE:-$(mktemp "${TMPDIR:-/tmp}/oats-coverage.XXXXXX")}"
 cleanup() {
 	if [[ -z "${COVERAGE_PROFILE:-}" ]]; then
 		rm -f "$profile"
@@ -24,7 +23,10 @@ if [[ -z "$package_list" ]]; then
 	echo "could not find packages to test" >&2
 	exit 1
 fi
-mapfile -t packages <<< "$package_list"
+packages=()
+while IFS= read -r pkg; do
+	[[ -n "$pkg" ]] && packages+=("$pkg")
+done <<< "$package_list"
 
 GOFLAGS=-buildvcs=false go test -coverprofile="$profile" "${packages[@]}"
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,6 +32,11 @@ mise run test
 mise run e2e-test
 ```
 
+Mise task implementations live in `.mise/tasks/` as executable [file tasks](https://mise.jdx.dev/tasks/file-tasks.html).
+Keep task scripts there rather than adding new mise-invoked scripts under
+`scripts/`; shared helpers used directly by CI or release workflows may remain
+in `scripts/`.
+
 ## Linting
 
 ```bash

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ fixture safety gate allows it.
   selects a release; `--gcx-download never` (or `OATS_GCX_DOWNLOAD=never`) keeps
   CI and air-gapped runs from downloading.
 - The pin is read from `mise.toml` by `scripts/gcx-version.sh`. Local builds use
-  `.mise/tasks/build`; e2e tool setup uses `mise run build-local-tools`;
+  `mise run build`; e2e tool setup uses `mise run build-local-tools`;
   GoReleaser receives the same value through `GCX_VERSION` in the release
   workflow. Do not hard-code a second gcx version in a script or workflow.
 - `OATS_GHA_ANNOTATIONS` controls the optional GitHub Actions error annotations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ fixture safety gate allows it.
   selects a release; `--gcx-download never` (or `OATS_GCX_DOWNLOAD=never`) keeps
   CI and air-gapped runs from downloading.
 - The pin is read from `mise.toml` by `scripts/gcx-version.sh`. Local builds use
-  `.mise/tasks/build`; local tool setup uses `scripts/build-local-tools.sh`;
+  `.mise/tasks/build`; e2e tool setup uses `mise run build-local-tools`;
   GoReleaser receives the same value through `GCX_VERSION` in the release
   workflow. Do not hard-code a second gcx version in a script or workflow.
 - `OATS_GHA_ANNOTATIONS` controls the optional GitHub Actions error annotations

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -98,7 +98,7 @@ fixture safety gate allows it.
   selects a release; `--gcx-download never` (or `OATS_GCX_DOWNLOAD=never`) keeps
   CI and air-gapped runs from downloading.
 - The pin is read from `mise.toml` by `scripts/gcx-version.sh`. Local builds use
-  `scripts/build-oats.sh`; local tool setup uses `scripts/build-local-tools.sh`;
+  `.mise/tasks/build`; local tool setup uses `scripts/build-local-tools.sh`;
   GoReleaser receives the same value through `GCX_VERSION` in the release
   workflow. Do not hard-code a second gcx version in a script or workflow.
 - `OATS_GHA_ANNOTATIONS` controls the optional GitHub Actions error annotations

--- a/mise.toml
+++ b/mise.toml
@@ -35,21 +35,9 @@ run = "flint run"
 description = "Auto-fix lint issues"
 run = "flint run --fix"
 
-[tasks.test]
-description = "Run tests"
-run = 'GOFLAGS=-buildvcs=false go test -coverprofile=coverage.out $(GOFLAGS=-buildvcs=false go list ./... | grep -v "github.com/grafana/oats/tests/e2e")'
-
 [tasks.e2e-test]
 description = "Run e2e cases"
 run = "go test -v -buildvcs=false ./tests/e2e -run TestCases"
-
-[tasks.example-test]
-description = "Run the self-contained examples"
-run = "bash ./.mise/tasks/example-test.sh"
-
-[tasks.build]
-description = "Build the project"
-run = "bash ./scripts/build-oats.sh"
 
 [tasks.check]
 description = "Run all checks"

--- a/scripts/build-local-tools.sh
+++ b/scripts/build-local-tools.sh
@@ -6,7 +6,7 @@ bin_dir="${1:-$root/bin}"
 mkdir -p "$bin_dir"
 gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 
-mise -C "$root" run build -- "$bin_dir/oats"
+mise run build -- "$bin_dir/oats"
 
 # CI and mise-based development already have the pinned gcx binary installed.
 # Reuse it instead of downloading and rebuilding a second copy. Direct

--- a/scripts/build-local-tools.sh
+++ b/scripts/build-local-tools.sh
@@ -6,7 +6,14 @@ bin_dir="${1:-$root/bin}"
 mkdir -p "$bin_dir"
 gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 
-mise run build -- "$bin_dir/oats"
+if command -v mise >/dev/null 2>&1; then
+	mise -C "$root" run build -- "$bin_dir/oats"
+else
+	GOWORK=off go -C "$root" build \
+		-buildvcs=false \
+		-ldflags "-X github.com/grafana/oats/internal/cli.MinimumGCXVersion=$gcx_version" \
+		-o "$bin_dir/oats" .
+fi
 
 # CI and mise-based development already have the pinned gcx binary installed.
 # Reuse it instead of downloading and rebuilding a second copy. Direct

--- a/scripts/build-local-tools.sh
+++ b/scripts/build-local-tools.sh
@@ -6,7 +6,7 @@ bin_dir="${1:-$root/bin}"
 mkdir -p "$bin_dir"
 gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 
-MISE_PROJECT_ROOT="$root" bash "$root/.mise/tasks/build" "$bin_dir/oats"
+mise -C "$root" run build -- "$bin_dir/oats"
 
 # CI and mise-based development already have the pinned gcx binary installed.
 # Reuse it instead of downloading and rebuilding a second copy. Direct

--- a/scripts/build-local-tools.sh
+++ b/scripts/build-local-tools.sh
@@ -6,7 +6,7 @@ bin_dir="${1:-$root/bin}"
 mkdir -p "$bin_dir"
 gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 
-bash "$root/scripts/build-oats.sh" "$bin_dir/oats"
+bash "$root/.mise/tasks/build" "$bin_dir/oats"
 
 # CI and mise-based development already have the pinned gcx binary installed.
 # Reuse it instead of downloading and rebuilding a second copy. Direct

--- a/scripts/build-local-tools.sh
+++ b/scripts/build-local-tools.sh
@@ -4,31 +4,18 @@ set -euo pipefail
 root="$(cd "$(dirname "$0")/.." && pwd)"
 bin_dir="${1:-$root/bin}"
 mkdir -p "$bin_dir"
-gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 
-if command -v mise >/dev/null 2>&1; then
-	mise -C "$root" run build -- "$bin_dir/oats"
-else
-	GOWORK=off go -C "$root" build \
-		-buildvcs=false \
-		-ldflags "-X github.com/grafana/oats/internal/cli.MinimumGCXVersion=$gcx_version" \
-		-o "$bin_dir/oats" .
-fi
+mise -C "$root" run build -- "$bin_dir/oats"
 
 # CI and mise-based development already have the pinned gcx binary installed.
-# Reuse it instead of downloading and rebuilding a second copy. Direct
-# `go test ./tests/e2e` remains self-contained by falling back to the version
-# pinned in mise.toml when mise is unavailable.
+# Reuse it instead of downloading and rebuilding a second copy.
 gcx_bin=""
-if command -v mise >/dev/null 2>&1; then
-	gcx_bin=$(mise -C "$root" which gcx 2>/dev/null || true)
-fi
+gcx_bin=$(mise -C "$root" which gcx 2>/dev/null || true)
 if [[ -n "$gcx_bin" && -x "$gcx_bin" ]]; then
 	install -m 0755 "$gcx_bin" "$bin_dir/gcx"
 else
-	# Keep this pin in mise.toml so Renovate updates the tool version rather than
-	# this script.
-	GOBIN="$bin_dir" GOWORK=off go install "github.com/grafana/gcx/cmd/gcx@v${gcx_version}"
+	echo "mise-managed gcx is required; run mise install" >&2
+	exit 1
 fi
 
 printf 'built %s/oats and %s/gcx\n' "$bin_dir" "$bin_dir"

--- a/scripts/build-local-tools.sh
+++ b/scripts/build-local-tools.sh
@@ -6,7 +6,7 @@ bin_dir="${1:-$root/bin}"
 mkdir -p "$bin_dir"
 gcx_version="$(bash "$root/scripts/gcx-version.sh")"
 
-bash "$root/.mise/tasks/build" "$bin_dir/oats"
+MISE_PROJECT_ROOT="$root" bash "$root/.mise/tasks/build" "$bin_dir/oats"
 
 # CI and mise-based development already have the pinned gcx binary installed.
 # Reuse it instead of downloading and rebuilding a second copy. Direct

--- a/scripts/build_test.go
+++ b/scripts/build_test.go
@@ -28,7 +28,7 @@ func TestBuildScripts(t *testing.T) {
 
 	output := filepath.Join(t.TempDir(), "oats")
 	projectRoot := filepath.Dir(root)
-	buildCmd := exec.Command("mise", "-C", projectRoot, "run", "build", "--", output)
+	buildCmd := exec.Command("mise", "run", "build", "--", output)
 	buildCmd.Dir = projectRoot
 	if output, err := buildCmd.CombinedOutput(); err != nil {
 		t.Fatalf("mise run build: %v\n%s", err, output)

--- a/scripts/build_test.go
+++ b/scripts/build_test.go
@@ -13,9 +13,6 @@ func TestBuildScripts(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("build scripts require bash")
 	}
-	if _, err := exec.LookPath("mise"); err != nil {
-		t.Skip("build scripts require mise")
-	}
 	root := filepath.Dir(mustCallerFile(t))
 
 	versionCmd := exec.Command("bash", filepath.Join(root, "gcx-version.sh"))

--- a/scripts/build_test.go
+++ b/scripts/build_test.go
@@ -13,6 +13,9 @@ func TestBuildScripts(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("build scripts require bash")
 	}
+	if _, err := exec.LookPath("mise"); err != nil {
+		t.Skip("build scripts require mise")
+	}
 	root := filepath.Dir(mustCallerFile(t))
 
 	versionCmd := exec.Command("bash", filepath.Join(root, "gcx-version.sh"))

--- a/scripts/build_test.go
+++ b/scripts/build_test.go
@@ -27,10 +27,10 @@ func TestBuildScripts(t *testing.T) {
 	}
 
 	output := filepath.Join(t.TempDir(), "oats")
-	buildCmd := exec.Command("bash", filepath.Join(root, "build-oats.sh"), output)
+	buildCmd := exec.Command("bash", filepath.Join(filepath.Dir(root), ".mise", "tasks", "build"), output)
 	buildCmd.Dir = filepath.Dir(root)
 	if output, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf("build-oats.sh: %v\n%s", err, output)
+		t.Fatalf(".mise/tasks/build: %v\n%s", err, output)
 	}
 	info, err := os.Stat(output)
 	if err != nil {

--- a/scripts/build_test.go
+++ b/scripts/build_test.go
@@ -27,12 +27,11 @@ func TestBuildScripts(t *testing.T) {
 	}
 
 	output := filepath.Join(t.TempDir(), "oats")
-	buildCmd := exec.Command("bash", filepath.Join(filepath.Dir(root), ".mise", "tasks", "build"), output)
 	projectRoot := filepath.Dir(root)
+	buildCmd := exec.Command("mise", "-C", projectRoot, "run", "build", "--", output)
 	buildCmd.Dir = projectRoot
-	buildCmd.Env = append(os.Environ(), "MISE_PROJECT_ROOT="+projectRoot)
 	if output, err := buildCmd.CombinedOutput(); err != nil {
-		t.Fatalf(".mise/tasks/build: %v\n%s", err, output)
+		t.Fatalf("mise run build: %v\n%s", err, output)
 	}
 	info, err := os.Stat(output)
 	if err != nil {

--- a/scripts/build_test.go
+++ b/scripts/build_test.go
@@ -28,7 +28,9 @@ func TestBuildScripts(t *testing.T) {
 
 	output := filepath.Join(t.TempDir(), "oats")
 	buildCmd := exec.Command("bash", filepath.Join(filepath.Dir(root), ".mise", "tasks", "build"), output)
-	buildCmd.Dir = filepath.Dir(root)
+	projectRoot := filepath.Dir(root)
+	buildCmd.Dir = projectRoot
+	buildCmd.Env = append(os.Environ(), "MISE_PROJECT_ROOT="+projectRoot)
 	if output, err := buildCmd.CombinedOutput(); err != nil {
 		t.Fatalf(".mise/tasks/build: %v\n%s", err, output)
 	}

--- a/tests/e2e/README.md
+++ b/tests/e2e/README.md
@@ -45,10 +45,20 @@ and shell commands:
 
 ## Filtering
 
+Run the e2e suite through the mise task:
+
+```bash
+mise run e2e-test
+```
+
 Use `OATS_E2E_FILTER` to run a subset of cases by relative path:
 
 ```bash
-OATS_E2E_FILTER=assert/ go test ./tests/e2e -run TestCases
-OATS_E2E_FILTER=fixture/remote go test ./tests/e2e -run TestCases
-OATS_E2E_FILTER=assert/contains,assert/regex go test ./tests/e2e -run TestCases
+OATS_E2E_FILTER=assert/ mise run e2e-test
+OATS_E2E_FILTER=fixture/remote mise run e2e-test
+OATS_E2E_FILTER=assert/contains,assert/regex mise run e2e-test
 ```
+
+For direct `go test` runs, mise must be installed and its tools must be
+available; alternatively, set `OATS_E2E_BIN_DIR` to a directory containing
+prebuilt `oats` and `gcx` binaries.

--- a/tests/e2e/e2e_test.go
+++ b/tests/e2e/e2e_test.go
@@ -251,7 +251,7 @@ func prepareLocalTools(env *sharedEnv) error {
 	}
 	start := time.Now()
 	fmt.Fprintf(os.Stderr, "e2e timing: building local tools into %s\n", binDir)
-	build := exec.Command("bash", "-lc", fmt.Sprintf("./scripts/build-local-tools.sh %q", binDir))
+	build := exec.Command("mise", "run", "build-local-tools", "--", binDir)
 	build.Dir = env.RepoRoot
 	build.Stdout = os.Stdout
 	build.Stderr = os.Stderr


### PR DESCRIPTION
## Summary

- move the `build`, `test`, `example-test`, and `build-local-tools` implementations into `.mise/tasks/`
- invoke file tasks through mise and use `MISE_PROJECT_ROOT`
- update direct CI/test callers and contributor documentation
- require mise for contributor build and e2e tooling while keeping released OATs binaries independent of mise
- preserve the coverage profile for Codecov, which enforces the 80% minimum

This is based on [PR #417](https://github.com/grafana/oats/pull/417), which is now merged. [PR #419](https://github.com/grafana/oats/pull/419) is stacked on this PR and contains the legacy YAML package isolation.

## Validation

- `mise run check` (lint and tests)
- `mise run build-local-tools -- /tmp/oats-tools-test`
- `go test -buildvcs=false ./tests/e2e -run '^$'`
- total coverage: 85.6%
