### PR TITLE
ci: upload Codecov base coverage on main

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,7 +1,11 @@
 ---
 name: Build and Test
 
-on: [pull_request]
+on:
+  push:
+    branches:
+      - main
+  pull_request:
 
 permissions: {}
 
@@ -29,4 +33,4 @@ jobs:
         with:
           fail_ci_if_error: true
           files: coverage.out
-          use_oidc: ${{ github.event.pull_request.head.repo.full_name == github.repository }}
+          use_oidc: ${{ github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository }}


### PR DESCRIPTION
## Summary

- Run the Build and Test workflow on pushes to `main` as well as pull requests.
- Upload main-branch coverage with OIDC so Codecov can calculate the base report for future PRs.
- Keep pull requests from forks on the existing tokenless upload path.

Without a base report, Codecov posts a coverage comment but cannot emit the `codecov/project` status.

## Validation

- `mise run check`
