### PR TITLE
ci: pin Podman Compose provider in Podman jobs

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -62,6 +62,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes podman podman-compose
+          echo "PODMAN_COMPOSE_PROVIDER=podman-compose" >> "$GITHUB_ENV"
       - name: Start rootless Podman service
         if: matrix.shard == 'compose-podman'
         run: |
@@ -170,6 +171,7 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install --yes podman podman-compose
+          echo "PODMAN_COMPOSE_PROVIDER=podman-compose" >> "$GITHUB_ENV"
       - name: Start rootless Podman service
         run: |
           socket="$XDG_RUNTIME_DIR/podman/podman.sock"

--- a/fixture/compose.go
+++ b/fixture/compose.go
@@ -312,6 +312,16 @@ func readComposeGrafanaToken(plan discovery.Plan, engine container.Engine) (stri
 }
 
 func composePort(engine container.Engine, files []string, env []string, service, containerPort string) (string, error) {
+	// podman-compose 1.0.6 cannot parse Compose's ephemeral port syntax
+	// (127.0.0.1::3000) in its `port` command. Query Podman directly first so
+	// the fixture lifecycle does not depend on which Compose provider Podman
+	// selected.
+	if engine == container.Podman {
+		if port, err := podmanPort(env, service, containerPort); err == nil {
+			return port, nil
+		}
+	}
+
 	args := engine.ComposeArgs()
 	for _, f := range files {
 		args = append(args, "-f", f)
@@ -331,6 +341,53 @@ func composePort(engine container.Engine, files []string, env []string, service,
 		return "", fmt.Errorf("invalid compose port output %q", strings.TrimSpace(string(out)))
 	}
 	return port, nil
+}
+
+func podmanPort(env []string, service, containerPort string) (string, error) {
+	project := ""
+	for _, entry := range env {
+		key, value, ok := strings.Cut(entry, "=")
+		if ok && key == "COMPOSE_PROJECT_NAME" {
+			project = value
+			break
+		}
+	}
+	if project == "" {
+		return "", fmt.Errorf("COMPOSE_PROJECT_NAME is required for Podman port lookup")
+	}
+
+	ps := exec.Command("podman", "ps", "-a",
+		"--filter", "label=com.docker.compose.project="+project,
+		"--filter", "label=com.docker.compose.service="+service,
+		"--format", "{{.ID}}")
+	ps.Env = append(ps.Environ(), env...)
+	containers, err := ps.Output()
+	if err != nil {
+		return "", err
+	}
+	containerID := strings.TrimSpace(strings.SplitN(string(containers), "\n", 2)[0])
+	if containerID == "" {
+		return "", fmt.Errorf("no Podman container found for project %q service %q", project, service)
+	}
+
+	port := exec.Command("podman", "port", containerID, containerPort)
+	port.Env = append(port.Environ(), env...)
+	out, err := port.Output()
+	if err != nil {
+		return "", err
+	}
+	line := strings.TrimSpace(strings.SplitN(string(out), "\n", 2)[0])
+	if arrow := strings.LastIndex(line, "->"); arrow >= 0 {
+		line = strings.TrimSpace(line[arrow+2:])
+	}
+	host, published, err := splitComposeHostPort(line)
+	if err != nil {
+		return "", err
+	}
+	if host == "" || published == "" {
+		return "", fmt.Errorf("invalid Podman port output %q", line)
+	}
+	return published, nil
 }
 
 func splitComposeHostPort(addr string) (string, string, error) {

--- a/fixture/compose.go
+++ b/fixture/compose.go
@@ -331,7 +331,7 @@ func composePort(engine container.Engine, files []string, env []string, service,
 	}
 	args = append(args, "port", service, containerPort)
 	cmd := exec.Command(engine.Binary(), args...)
-	cmd.Env = append(cmd.Environ(), env...)
+	cmd.Env = mergeEnvironment(cmd.Environ(), env)
 	out, err := cmd.Output()
 	if err != nil {
 		return "", composePortError(podmanErr, err)
@@ -353,6 +353,24 @@ func composePortError(podmanErr, composeErr error) error {
 	return fmt.Errorf("podman port lookup: %v; compose port lookup: %w", podmanErr, composeErr)
 }
 
+func mergeEnvironment(parent, override []string) []string {
+	merged := make([]string, 0, len(parent)+len(override))
+	index := make(map[string]int, len(parent)+len(override))
+	for _, entry := range append(append([]string(nil), parent...), override...) {
+		key := entry
+		if separator := strings.IndexByte(entry, '='); separator >= 0 {
+			key = entry[:separator]
+		}
+		if position, ok := index[key]; ok {
+			merged[position] = entry
+			continue
+		}
+		index[key] = len(merged)
+		merged = append(merged, entry)
+	}
+	return merged
+}
+
 func podmanPort(env []string, service, containerPort string) (string, error) {
 	project := ""
 	for i := len(env) - 1; i >= 0; i-- {
@@ -367,11 +385,11 @@ func podmanPort(env []string, service, containerPort string) (string, error) {
 		return "", fmt.Errorf("COMPOSE_PROJECT_NAME is required for Podman port lookup")
 	}
 
-	ps := exec.Command("podman", "ps",
+	ps := exec.Command(container.Podman.Binary(), "ps",
 		"--filter", "label=com.docker.compose.project="+project,
 		"--filter", "label=com.docker.compose.service="+service,
 		"--format", "{{.ID}}")
-	ps.Env = append(ps.Environ(), env...)
+	ps.Env = mergeEnvironment(ps.Environ(), env)
 	containers, err := ps.Output()
 	if err != nil {
 		return "", err
@@ -381,8 +399,8 @@ func podmanPort(env []string, service, containerPort string) (string, error) {
 		return "", fmt.Errorf("no Podman container found for project %q service %q", project, service)
 	}
 
-	port := exec.Command("podman", "port", containerID, containerPort)
-	port.Env = append(port.Environ(), env...)
+	port := exec.Command(container.Podman.Binary(), "port", containerID, containerPort)
+	port.Env = mergeEnvironment(port.Environ(), env)
 	out, err := port.Output()
 	if err != nil {
 		return "", err

--- a/fixture/compose.go
+++ b/fixture/compose.go
@@ -345,7 +345,8 @@ func composePort(engine container.Engine, files []string, env []string, service,
 
 func podmanPort(env []string, service, containerPort string) (string, error) {
 	project := ""
-	for _, entry := range env {
+	for i := len(env) - 1; i >= 0; i-- {
+		entry := env[i]
 		key, value, ok := strings.Cut(entry, "=")
 		if ok && key == "COMPOSE_PROJECT_NAME" {
 			project = value

--- a/fixture/compose.go
+++ b/fixture/compose.go
@@ -316,8 +316,11 @@ func composePort(engine container.Engine, files []string, env []string, service,
 	// (127.0.0.1::3000) in its `port` command. Query Podman directly first so
 	// the fixture lifecycle does not depend on which Compose provider Podman
 	// selected.
+	var podmanErr error
 	if engine == container.Podman {
-		if port, err := podmanPort(env, service, containerPort); err == nil {
+		var port string
+		port, podmanErr = podmanPort(env, service, containerPort)
+		if podmanErr == nil {
 			return port, nil
 		}
 	}
@@ -331,16 +334,23 @@ func composePort(engine container.Engine, files []string, env []string, service,
 	cmd.Env = append(cmd.Environ(), env...)
 	out, err := cmd.Output()
 	if err != nil {
-		return "", err
+		return "", composePortError(podmanErr, err)
 	}
 	host, port, err := splitComposeHostPort(strings.TrimSpace(string(out)))
 	if err != nil {
-		return "", err
+		return "", composePortError(podmanErr, err)
 	}
 	if host == "" || port == "" {
-		return "", fmt.Errorf("invalid compose port output %q", strings.TrimSpace(string(out)))
+		return "", composePortError(podmanErr, fmt.Errorf("invalid compose port output %q", strings.TrimSpace(string(out))))
 	}
 	return port, nil
+}
+
+func composePortError(podmanErr, composeErr error) error {
+	if podmanErr == nil {
+		return composeErr
+	}
+	return fmt.Errorf("podman port lookup: %v; compose port lookup: %w", podmanErr, composeErr)
 }
 
 func podmanPort(env []string, service, containerPort string) (string, error) {
@@ -357,7 +367,7 @@ func podmanPort(env []string, service, containerPort string) (string, error) {
 		return "", fmt.Errorf("COMPOSE_PROJECT_NAME is required for Podman port lookup")
 	}
 
-	ps := exec.Command("podman", "ps", "-a",
+	ps := exec.Command("podman", "ps",
 		"--filter", "label=com.docker.compose.project="+project,
 		"--filter", "label=com.docker.compose.service="+service,
 		"--format", "{{.ID}}")

--- a/fixture/fixture_helpers_test.go
+++ b/fixture/fixture_helpers_test.go
@@ -64,6 +64,10 @@ func TestComposeHelpers(t *testing.T) {
 	if !containsString(env, "OATS_COMPOSE_FILE_ARGS=-f '/cases/compose.yml'") {
 		t.Errorf("composeCheckEnv missing quoted file args in %#v", env)
 	}
+	mergedEnv := mergeEnvironment([]string{"COMPOSE_PROJECT_NAME=parent", "PATH=/bin"}, []string{"COMPOSE_PROJECT_NAME=child", "OATS_TEST=1"})
+	if len(mergedEnv) != 3 || !containsString(mergedEnv, "COMPOSE_PROJECT_NAME=child") || containsString(mergedEnv, "COMPOSE_PROJECT_NAME=parent") {
+		t.Errorf("mergeEnvironment = %#v", mergedEnv)
+	}
 
 	noFiles := composeCheckEnv(plan, Runtime{})
 	if len(noFiles) != 1 || noFiles[0] != "OATS_FIXTURE_TYPE=compose" {
@@ -180,9 +184,9 @@ esac
 	podman := filepath.Join(bin, "podman")
 	if err := os.WriteFile(podman, []byte(`#!/bin/sh
 case "$*" in
-ps\ -a*) printf 'stopped-container-lookup\n' >&2; exit 1 ;;
-ps\ *) printf 'container-id\n' ;;
-*port*) printf '3000/tcp -> 127.0.0.1:55432\n' ;;
+"ps --filter label=com.docker.compose.project=oats-test --filter label=com.docker.compose.service=lgtm --format {{.ID}}") printf 'container-id\n' ;;
+"port container-id 3000") printf '3000/tcp -> 127.0.0.1:55432\n' ;;
+*) printf 'unexpected podman args: %s\n' "$*" >&2; exit 1 ;;
 esac
 `), 0o700); err != nil {
 		t.Fatal(err)

--- a/fixture/fixture_helpers_test.go
+++ b/fixture/fixture_helpers_test.go
@@ -180,6 +180,7 @@ esac
 	podman := filepath.Join(bin, "podman")
 	if err := os.WriteFile(podman, []byte(`#!/bin/sh
 case "$*" in
+ps\ -a*) printf 'stopped-container-lookup\n' >&2; exit 1 ;;
 ps\ *) printf 'container-id\n' ;;
 *port*) printf '3000/tcp -> 127.0.0.1:55432\n' ;;
 esac
@@ -198,6 +199,23 @@ esac
 	}
 	if got, err := composePort(container.Podman, files, []string{"COMPOSE_PROJECT_NAME=oats-test"}, "lgtm", "3000"); err != nil || got != "55432" {
 		t.Fatalf("Podman composePort = %q, %v", got, err)
+	}
+
+	if got, err := podmanPort(nil, "lgtm", "3000"); err == nil || got != "" || !strings.Contains(err.Error(), "COMPOSE_PROJECT_NAME is required") {
+		t.Fatalf("podmanPort without project = %q, %v", got, err)
+	}
+
+	if err := os.WriteFile(podman, []byte(`#!/bin/sh
+case "$*" in
+ps\ *) printf 'container-id\n' ;;
+compose*) exit 1 ;;
+*port*) printf 'invalid-port\n' ;;
+esac
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if got, err := composePort(container.Podman, files, []string{"COMPOSE_PROJECT_NAME=oats-test"}, "lgtm", "3000"); err == nil || got != "" || !strings.Contains(err.Error(), "podman port lookup") || !strings.Contains(err.Error(), "compose port lookup") {
+		t.Fatalf("composePort combined error = %q, %v", got, err)
 	}
 	plan := discovery.Plan{
 		FixtureSourceDir: dir,

--- a/fixture/fixture_helpers_test.go
+++ b/fixture/fixture_helpers_test.go
@@ -177,6 +177,15 @@ esac
 `), 0o700); err != nil {
 		t.Fatal(err)
 	}
+	podman := filepath.Join(bin, "podman")
+	if err := os.WriteFile(podman, []byte(`#!/bin/sh
+case "$*" in
+ps\ *) printf 'container-id\n' ;;
+*port*) printf '3000/tcp -> 127.0.0.1:55432\n' ;;
+esac
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
 	kubectl := filepath.Join(bin, "kubectl")
 	if err := os.WriteFile(kubectl, []byte("#!/bin/sh\nprintf 'k3d-token\\n'\n"), 0o700); err != nil {
 		t.Fatal(err)
@@ -186,6 +195,9 @@ esac
 	files := []string{"compose.yml"}
 	if got, err := composePort(container.Docker, files, nil, "lgtm", "3000"); err != nil || got != "5432" {
 		t.Fatalf("composePort = %q, %v", got, err)
+	}
+	if got, err := composePort(container.Podman, files, []string{"COMPOSE_PROJECT_NAME=oats-test"}, "lgtm", "3000"); err != nil || got != "55432" {
+		t.Fatalf("Podman composePort = %q, %v", got, err)
 	}
 	plan := discovery.Plan{
 		FixtureSourceDir: dir,

--- a/fixture/fixture_helpers_test.go
+++ b/fixture/fixture_helpers_test.go
@@ -217,6 +217,72 @@ esac
 	if got, err := composePort(container.Podman, files, []string{"COMPOSE_PROJECT_NAME=oats-test"}, "lgtm", "3000"); err == nil || got != "" || !strings.Contains(err.Error(), "podman port lookup") || !strings.Contains(err.Error(), "compose port lookup") {
 		t.Fatalf("composePort combined error = %q, %v", got, err)
 	}
+	if err := composePortError(nil, errors.New("compose failed")); err == nil || err.Error() != "compose failed" {
+		t.Fatalf("composePortError without Podman error = %v", err)
+	}
+
+	writePodman := func(script string) {
+		t.Helper()
+		if err := os.WriteFile(podman, []byte(script), 0o700); err != nil {
+			t.Fatal(err)
+		}
+	}
+	testPodmanPortError := func(name, script, want string) {
+		t.Helper()
+		t.Run(name, func(t *testing.T) {
+			writePodman(script)
+			if got, err := podmanPort([]string{"COMPOSE_PROJECT_NAME=oats-test"}, "lgtm", "3000"); err == nil || got != "" || !strings.Contains(err.Error(), want) {
+				t.Errorf("podmanPort = %q, %v; want error containing %q", got, err, want)
+			}
+		})
+	}
+	testPodmanPortError("ps failure", `#!/bin/sh
+case "$*" in
+ps\ *) exit 1 ;;
+esac
+`, "exit status 1")
+	testPodmanPortError("empty container", `#!/bin/sh
+case "$*" in
+ps\ *) printf '\n' ;;
+esac
+`, "no Podman container found")
+	testPodmanPortError("port failure", `#!/bin/sh
+case "$*" in
+ps\ *) printf 'container-id\n' ;;
+*port*) exit 1 ;;
+esac
+`, "exit status 1")
+	testPodmanPortError("invalid port", `#!/bin/sh
+case "$*" in
+ps\ *) printf 'container-id\n' ;;
+*port*) printf 'invalid-port\n' ;;
+esac
+`, "invalid address")
+	testPodmanPortError("empty published port", `#!/bin/sh
+case "$*" in
+ps\ *) printf 'container-id\n' ;;
+*port*) printf '127.0.0.1:\n' ;;
+esac
+`, "invalid Podman port output")
+
+	writePodman(`#!/bin/sh
+case "$*" in
+ps\ *) exit 1 ;;
+compose*) printf 'invalid-compose-output\n' ;;
+esac
+`)
+	if got, err := composePort(container.Podman, files, []string{"COMPOSE_PROJECT_NAME=oats-test"}, "lgtm", "3000"); err == nil || got != "" || !strings.Contains(err.Error(), "invalid address") {
+		t.Fatalf("composePort invalid fallback = %q, %v", got, err)
+	}
+	writePodman(`#!/bin/sh
+case "$*" in
+ps\ *) exit 1 ;;
+compose*) printf ':55432\n' ;;
+esac
+`)
+	if got, err := composePort(container.Podman, files, []string{"COMPOSE_PROJECT_NAME=oats-test"}, "lgtm", "3000"); err == nil || got != "" || !strings.Contains(err.Error(), "invalid compose port output") {
+		t.Fatalf("composePort empty fallback = %q, %v", got, err)
+	}
 	plan := discovery.Plan{
 		FixtureSourceDir: dir,
 		Fixture:          casefile.FixtureConfig{Compose: &casefile.ComposeFixture{Template: "none", File: "compose.yml"}},

--- a/runner/checks.go
+++ b/runner/checks.go
@@ -145,7 +145,12 @@ func searchComposeLogs(ctx context.Context, extraEnv []string, needle string) (b
 		}
 		engine = parsed
 	}
-	cmd := exec.CommandContext(ctx, engine.Binary(), engine.ComposeArgs("logs", "--no-color")...)
+	args := []string{"logs"}
+	if engine != container.Podman {
+		// podman-compose 1.0.6 does not implement Compose's --no-color flag.
+		args = append(args, "--no-color")
+	}
+	cmd := exec.CommandContext(ctx, engine.Binary(), engine.ComposeArgs(args...)...)
 	cmd.Env = append(cmd.Environ(), extraEnv...)
 	var out bytes.Buffer
 	cmd.Stdout = &out

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -438,7 +438,7 @@ expected:
 func TestSearchComposeLogs_UsesPodman(t *testing.T) {
 	dir := t.TempDir()
 	podman := filepath.Join(dir, "podman")
-	if err := os.WriteFile(podman, []byte("#!/bin/sh\nprintf '%s\\n' \"$*\"; echo 'podman service started'\n"), 0o755); err != nil {
+	if err := os.WriteFile(podman, []byte("#!/bin/sh\ncase \"$*\" in\n  'compose logs') echo 'podman service started' ;;\n  *) echo \"unexpected args: $*\" >&2; exit 1 ;;\nesac\n"), 0o755); err != nil {
 		t.Fatalf("WriteFile: %v", err)
 	}
 	t.Setenv("PATH", dir+string(os.PathListSeparator)+os.Getenv("PATH"))

--- a/testhelpers/compose/compose.go
+++ b/testhelpers/compose/compose.go
@@ -124,7 +124,9 @@ func (c *Compose) Stop() error {
 }
 
 func (c *Compose) Remove() error {
-	return c.runDocker(newCommand("rm", "-f"))
+	// `down` is supported by both Docker Compose and podman-compose. The
+	// latter does not implement Compose's `rm` command.
+	return c.runDocker(newCommand("down"))
 }
 
 func (c *Compose) runDocker(cc command) error {

--- a/testhelpers/compose/compose_test.go
+++ b/testhelpers/compose/compose_test.go
@@ -79,7 +79,7 @@ esac
 		"-f base.yml -f override.yml up --build --detach --force-recreate",
 		"-f base.yml -f override.yml logs",
 		"-f base.yml -f override.yml stop",
-		"-f base.yml -f override.yml rm -f",
+		"-f base.yml -f override.yml down",
 	} {
 		if !strings.Contains(string(data), want) {
 			t.Errorf("command log %q missing %q", data, want)


### PR DESCRIPTION
## Summary

- explicitly select `podman-compose` in the Podman-backed e2e jobs
- use Compose commands supported by both Docker Compose and podman-compose for teardown and log checks
- resolve ephemeral Podman-published ports without relying on podman-compose's incompatible `compose port` implementation

## Why

The [e2e run for PR #422](https://github.com/grafana/oats/pull/422) failed only in `examples-podman`, while an earlier run of the same commit passed. The failed run showed the application could not resolve the `lgtm` service and that `podman compose` had selected the preinstalled Docker Compose provider, even though CI installed `podman-compose`.

Persisting `PODMAN_COMPOSE_PROVIDER=podman-compose` makes the CI setup use the provider it installed. That exposed a few podman-compose 1.0.6 compatibility gaps in the shared helpers: it has no `rm` command, cannot parse ephemeral port mappings in `compose port`, and rejects `logs --no-color`. The follow-up commits keep the lifecycle portable across both Compose providers.

## Validation

- `mise run lint`
- `mise run test`
- `mise run build`
- all PR checks, including `examples-podman` and `test-e2e (compose-podman)`, pass
