### PR TITLE
fix: fall back when Compose engine is unreachable

### DIFF
--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -201,12 +201,58 @@ jobs:
           OATS_EXAMPLE_MODE: compose
         run: mise run example-test
 
+  # Exercise auto selection when Podman is installed but its Compose provider
+  # cannot reach the engine. Docker remains healthy, so OATS must fall back to
+  # Docker after the Podman probe fails.
+  examples-auto-fallback:
+    needs: build-e2e-tools
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Check out
+        uses: actions/checkout@3d3c42e5aac5ba805825da76410c181273ba90b1 # v7.0.1
+        with:
+          persist-credentials: false
+      - uses: jdx/mise-action@dad1bfd3df957f44999b559dd69dc1671cb4e9ea # v4.2.1
+        with:
+          version: v2026.7.7
+          sha256: 429f71e7e989908bf975aafac9066329c16e2d8fc7cd8e74fdf21dd6300ffe7c
+      - name: Install Podman Compose provider
+        run: |
+          sudo apt-get update
+          sudo apt-get install --yes docker-compose podman
+          mkdir -p "$RUNNER_TEMP/unavailable-podman-bin"
+          cat >"$RUNNER_TEMP/unavailable-podman-bin/podman" <<'EOF'
+          #!/usr/bin/env bash
+          set -euo pipefail
+          if [[ "${1:-}" == compose ]]; then
+            export DOCKER_HOST="unix://${RUNNER_TEMP}/unavailable-podman.sock"
+          fi
+          exec /usr/bin/podman "$@"
+          EOF
+          chmod +x "$RUNNER_TEMP/unavailable-podman-bin/podman"
+          echo "$RUNNER_TEMP/unavailable-podman-bin" >>"$GITHUB_PATH"
+          echo "PODMAN_COMPOSE_PROVIDER=docker-compose" >>"$GITHUB_ENV"
+      - name: Download e2e tools
+        uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
+        with:
+          name: e2e-tools
+          path: .e2e-tools/bin
+      - name: Restore e2e tool permissions
+        run: chmod +x .e2e-tools/bin/oats .e2e-tools/bin/gcx
+      - name: Run Compose examples with automatic fallback
+        env:
+          OATS_BIN: ${{ github.workspace }}/.e2e-tools/bin/oats
+          GCX_BIN: ${{ github.workspace }}/.e2e-tools/bin/gcx
+          OATS_CONTAINER_RUNTIME: auto
+          OATS_EXAMPLE_MODE: compose
+        run: mise run example-test
+
   # Single required check. Branch protection can require just `e2e` instead of
   # every matrix leg, so adding/renaming shards never silently drops coverage.
   # `needs` on the matrix job succeeds only if all its legs did; if: always()
   # makes this run (and go red) even when a dependency fails or is skipped.
   e2e:
-    needs: [test-e2e, examples, examples-podman]
+    needs: [test-e2e, examples, examples-podman, examples-auto-fallback]
     if: always()
     runs-on: ubuntu-24.04
     steps:
@@ -215,6 +261,7 @@ jobs:
           TEST_E2E_RESULT: ${{ needs.test-e2e.result }}
           EXAMPLES_RESULT: ${{ needs.examples.result }}
           EXAMPLES_PODMAN_RESULT: ${{ needs.examples-podman.result }}
+          EXAMPLES_AUTO_FALLBACK_RESULT: ${{ needs.examples-auto-fallback.result }}
         run: |
-          echo "test-e2e=$TEST_E2E_RESULT examples=$EXAMPLES_RESULT examples-podman=$EXAMPLES_PODMAN_RESULT"
-          [ "$TEST_E2E_RESULT" = "success" ] && [ "$EXAMPLES_RESULT" = "success" ] && [ "$EXAMPLES_PODMAN_RESULT" = "success" ]
+          echo "test-e2e=$TEST_E2E_RESULT examples=$EXAMPLES_RESULT examples-podman=$EXAMPLES_PODMAN_RESULT examples-auto-fallback=$EXAMPLES_AUTO_FALLBACK_RESULT"
+          [ "$TEST_E2E_RESULT" = "success" ] && [ "$EXAMPLES_RESULT" = "success" ] && [ "$EXAMPLES_PODMAN_RESULT" = "success" ] && [ "$EXAMPLES_AUTO_FALLBACK_RESULT" = "success" ]

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -249,17 +249,18 @@ jobs:
 
   # Single required check. Branch protection can require just `e2e` instead of
   # every matrix leg, so adding/renaming shards never silently drops coverage.
-  # `needs` on the matrix job succeeds only if all its legs did; the wildcard
-  # result check below keeps this summary in sync as dependent jobs change.
+  # `always()` ensures this summary runs when a dependent job fails or is
+  # skipped; the wildcard result check below keeps it in sync as dependent
+  # jobs change.
   e2e:
     needs: [test-e2e, examples, examples-podman, examples-auto-fallback]
-    if: ${{ !cancelled() }}
+    if: ${{ always() }}
     runs-on: ubuntu-24.04
     steps:
       - name: Report status
         shell: bash
         env:
-          E2E_SUCCESS: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
+          E2E_SUCCESS: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') && !contains(needs.*.result, 'skipped') }}
         run: |
           if [ "$E2E_SUCCESS" = "true" ]; then
             echo 'E2E tests successful'

--- a/.github/workflows/e2e_test.yml
+++ b/.github/workflows/e2e_test.yml
@@ -249,19 +249,21 @@ jobs:
 
   # Single required check. Branch protection can require just `e2e` instead of
   # every matrix leg, so adding/renaming shards never silently drops coverage.
-  # `needs` on the matrix job succeeds only if all its legs did; if: always()
-  # makes this run (and go red) even when a dependency fails or is skipped.
+  # `needs` on the matrix job succeeds only if all its legs did; the wildcard
+  # result check below keeps this summary in sync as dependent jobs change.
   e2e:
     needs: [test-e2e, examples, examples-podman, examples-auto-fallback]
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     steps:
-      - name: Check e2e results
+      - name: Report status
+        shell: bash
         env:
-          TEST_E2E_RESULT: ${{ needs.test-e2e.result }}
-          EXAMPLES_RESULT: ${{ needs.examples.result }}
-          EXAMPLES_PODMAN_RESULT: ${{ needs.examples-podman.result }}
-          EXAMPLES_AUTO_FALLBACK_RESULT: ${{ needs.examples-auto-fallback.result }}
+          E2E_SUCCESS: ${{ !contains(needs.*.result, 'failure') && !contains(needs.*.result, 'cancelled') }}
         run: |
-          echo "test-e2e=$TEST_E2E_RESULT examples=$EXAMPLES_RESULT examples-podman=$EXAMPLES_PODMAN_RESULT examples-auto-fallback=$EXAMPLES_AUTO_FALLBACK_RESULT"
-          [ "$TEST_E2E_RESULT" = "success" ] && [ "$EXAMPLES_RESULT" = "success" ] && [ "$EXAMPLES_PODMAN_RESULT" = "success" ] && [ "$EXAMPLES_AUTO_FALLBACK_RESULT" = "success" ]
+          if [ "$E2E_SUCCESS" = "true" ]; then
+            echo 'E2E tests successful'
+          else
+            echo 'E2E tests failed'
+            exit 1
+          fi

--- a/testhelpers/container/container.go
+++ b/testhelpers/container/container.go
@@ -4,9 +4,12 @@
 package container
 
 import (
+	"context"
 	"fmt"
+	"os"
 	"os/exec"
 	"strings"
+	"time"
 )
 
 // Engine is a supported host container engine.
@@ -66,6 +69,34 @@ func available(engine Engine) error {
 	// instead of failing later during fixture startup.
 	if err := exec.Command(engine.Binary(), "compose", "version").Run(); err != nil {
 		return fmt.Errorf("compose unavailable: %w", err)
+	}
+	// `compose version` only checks the client/provider. A provider can still
+	// be unable to reach the engine API, which is common when Podman is
+	// installed but its service socket is not running. Probe a harmless empty
+	// Compose project so auto mode can try the next engine before fixture
+	// startup.
+	probe, err := os.CreateTemp("", "oats-runtime-probe-*.compose.yml")
+	if err != nil {
+		return fmt.Errorf("create compose probe: %w", err)
+	}
+	probePath := probe.Name()
+	defer func() { _ = os.Remove(probePath) }()
+	if _, err := probe.WriteString("services:\n  oats-runtime-probe:\n    image: scratch\n"); err != nil {
+		_ = probe.Close()
+		return fmt.Errorf("write compose probe: %w", err)
+	}
+	if err := probe.Close(); err != nil {
+		return fmt.Errorf("close compose probe: %w", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+	defer cancel()
+	if output, err := exec.CommandContext(ctx, engine.Binary(), "compose", "-f", probePath, "ps", "--all", "--quiet").CombinedOutput(); err != nil {
+		message := strings.TrimSpace(string(output))
+		if message != "" {
+			return fmt.Errorf("container engine unavailable: %s: %w", message, err)
+		}
+		return fmt.Errorf("container engine unavailable: %w", err)
 	}
 	return nil
 }

--- a/testhelpers/container/container.go
+++ b/testhelpers/container/container.go
@@ -91,7 +91,7 @@ func available(engine Engine) error {
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()
-	if output, err := exec.CommandContext(ctx, engine.Binary(), "compose", "-f", probePath, "ps", "--all", "--quiet").CombinedOutput(); err != nil {
+	if output, err := exec.CommandContext(ctx, engine.Binary(), "compose", "-f", probePath, "ps").CombinedOutput(); err != nil {
 		message := strings.TrimSpace(string(output))
 		if message != "" {
 			return fmt.Errorf("container engine unavailable: %s: %w", message, err)

--- a/testhelpers/container/container.go
+++ b/testhelpers/container/container.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"time"
 )
@@ -81,18 +82,14 @@ func available(engine Engine) error {
 	// installed but its service socket is not running. Probe a harmless empty
 	// Compose project so auto mode can try the next engine before fixture
 	// startup.
-	probe, err := os.CreateTemp("", "oats-runtime-probe-*.compose.yml")
+	probeDir, err := os.MkdirTemp("", "oats-runtime-probe-")
 	if err != nil {
-		return fmt.Errorf("create compose probe: %w", err)
+		return fmt.Errorf("create compose probe directory: %w", err)
 	}
-	probePath := probe.Name()
-	defer func() { _ = os.Remove(probePath) }()
-	if _, err := probe.WriteString("services:\n  oats-runtime-probe:\n    image: scratch\n"); err != nil {
-		_ = probe.Close()
+	defer func() { _ = os.RemoveAll(probeDir) }()
+	probePath := filepath.Join(probeDir, "compose.yml")
+	if err := os.WriteFile(probePath, []byte("services:\n  oats-runtime-probe:\n    image: scratch\n"), 0o600); err != nil {
 		return fmt.Errorf("write compose probe: %w", err)
-	}
-	if err := probe.Close(); err != nil {
-		return fmt.Errorf("close compose probe: %w", err)
 	}
 
 	if output, err := runComposeProbe(engine, "-f", probePath, "ps"); err != nil {
@@ -108,7 +105,11 @@ func available(engine Engine) error {
 func runComposeProbe(engine Engine, args ...string) ([]byte, error) {
 	ctx, cancel := context.WithTimeout(context.Background(), composeProbeTimeout)
 	defer cancel()
-	return exec.CommandContext(ctx, engine.Binary(), append([]string{"compose"}, args...)...).CombinedOutput()
+	output, err := exec.CommandContext(ctx, engine.Binary(), append([]string{"compose"}, args...)...).CombinedOutput()
+	if err != nil && ctx.Err() == context.DeadlineExceeded {
+		return output, fmt.Errorf("compose probe timed out after %s: %w", composeProbeTimeout, ctx.Err())
+	}
+	return output, err
 }
 
 // Binary returns the executable used by the engine.

--- a/testhelpers/container/container.go
+++ b/testhelpers/container/container.go
@@ -21,6 +21,8 @@ const (
 	Auto   Engine = "auto"
 	Docker Engine = "docker"
 	Podman Engine = "podman"
+
+	composeProbeTimeout = 5 * time.Second
 )
 
 // Parse validates a requested engine name. An empty value means Auto.
@@ -67,7 +69,11 @@ func available(engine Engine) error {
 	// may be an optional CLI plugin. Probe both during selection so an engine
 	// without a usable Compose implementation fails with an actionable error
 	// instead of failing later during fixture startup.
-	if err := exec.Command(engine.Binary(), "compose", "version").Run(); err != nil {
+	if output, err := runComposeProbe(engine, "version"); err != nil {
+		message := strings.TrimSpace(string(output))
+		if message != "" {
+			return fmt.Errorf("compose unavailable: %s: %w", message, err)
+		}
 		return fmt.Errorf("compose unavailable: %w", err)
 	}
 	// `compose version` only checks the client/provider. A provider can still
@@ -89,9 +95,7 @@ func available(engine Engine) error {
 		return fmt.Errorf("close compose probe: %w", err)
 	}
 
-	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
-	defer cancel()
-	if output, err := exec.CommandContext(ctx, engine.Binary(), "compose", "-f", probePath, "ps").CombinedOutput(); err != nil {
+	if output, err := runComposeProbe(engine, "-f", probePath, "ps"); err != nil {
 		message := strings.TrimSpace(string(output))
 		if message != "" {
 			return fmt.Errorf("container engine unavailable: %s: %w", message, err)
@@ -99,6 +103,12 @@ func available(engine Engine) error {
 		return fmt.Errorf("container engine unavailable: %w", err)
 	}
 	return nil
+}
+
+func runComposeProbe(engine Engine, args ...string) ([]byte, error) {
+	ctx, cancel := context.WithTimeout(context.Background(), composeProbeTimeout)
+	defer cancel()
+	return exec.CommandContext(ctx, engine.Binary(), append([]string{"compose"}, args...)...).CombinedOutput()
 }
 
 // Binary returns the executable used by the engine.

--- a/testhelpers/container/container_test.go
+++ b/testhelpers/container/container_test.go
@@ -110,3 +110,32 @@ func TestResolveAutoPrefersPodman(t *testing.T) {
 		t.Fatalf("Resolve(auto) = %q, want %q", got, Podman)
 	}
 }
+
+func TestResolveAutoFallsBackWhenPodmanEngineIsUnavailable(t *testing.T) {
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses POSIX executables")
+	}
+	podman := filepath.Join(dir, "podman")
+	if err := os.WriteFile(podman, []byte(`#!/bin/sh
+if [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+  exit 0
+fi
+exit 1
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	docker := filepath.Join(dir, "docker")
+	if err := os.WriteFile(docker, []byte("#!/bin/sh\nexit 0\n"), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := Resolve("auto")
+	if err != nil {
+		t.Fatalf("Resolve(auto): %v", err)
+	}
+	if got != Docker {
+		t.Fatalf("Resolve(auto) = %q, want %q", got, Docker)
+	}
+}

--- a/testhelpers/container/container_test.go
+++ b/testhelpers/container/container_test.go
@@ -139,3 +139,31 @@ exit 1
 		t.Fatalf("Resolve(auto) = %q, want %q", got, Docker)
 	}
 }
+
+func TestResolveAutoUsesPortableComposeProbe(t *testing.T) {
+	dir := t.TempDir()
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses POSIX executables")
+	}
+	podman := filepath.Join(dir, "podman")
+	if err := os.WriteFile(podman, []byte(`#!/bin/sh
+if [ "$1" = "compose" ] && [ "$2" = "version" ]; then
+  exit 0
+fi
+if [ "$1" = "compose" ] && [ "$2" = "-f" ] && [ "$4" = "ps" ] && [ "$#" -eq 4 ]; then
+  exit 0
+fi
+exit 1
+`), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", dir)
+
+	got, err := Resolve("auto")
+	if err != nil {
+		t.Fatalf("Resolve(auto): %v", err)
+	}
+	if got != Podman {
+		t.Fatalf("Resolve(auto) = %q, want %q", got, Podman)
+	}
+}


### PR DESCRIPTION
## Summary

- probe the selected Compose provider and engine API before starting fixtures
- allow `auto` to fall back from an installed but unavailable Podman service to Docker
- keep explicit `docker`/`podman` selections strict

## Validation

- `mise run test`
- `mise run lint`
- `git diff --check`