### PR TITLE
fix(cli): restore --lgtm-version flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,7 +80,7 @@ For Compose fixtures, OATS prefers Podman when it is available and falls back
 to Docker. Use `--container-runtime docker` (or
 `OATS_CONTAINER_RUNTIME=docker`) to make the engine explicit. k3d fixtures
 currently require Docker. The builtin Compose fixture uses the latest
-`grafana/otel-lgtm` image by default; select another image version with
+`docker.io/grafana/otel-lgtm` image by default; select another image version with
 `--lgtm-version <version>` (or `OATS_LGTM_VERSION`). To override the complete
 image reference, set `LGTM_IMAGE`, for example
 `LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2`.

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ currently require Docker. The builtin Compose fixture uses the latest
 `docker.io/grafana/otel-lgtm` image by default; select another image version with
 `--lgtm-version <version>` (or `OATS_LGTM_VERSION`). To override the complete
 image reference, set `LGTM_IMAGE`, for example
-`LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2`.
+`LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.29.1`.
 
 ## Getting started
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,11 @@ exact release with `--gcx-version <version>`.
 For Compose fixtures, OATS prefers Podman when it is available and falls back
 to Docker. Use `--container-runtime docker` (or
 `OATS_CONTAINER_RUNTIME=docker`) to make the engine explicit. k3d fixtures
-currently require Docker.
+currently require Docker. The builtin Compose fixture uses the latest
+`grafana/otel-lgtm` image by default; select another image version with
+`--lgtm-version <version>` (or `OATS_LGTM_VERSION`). To override the complete
+image reference, set `LGTM_IMAGE`, for example
+`LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2`.
 
 ## Getting started
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -25,7 +25,7 @@ oats migrate path/to/legacy.yaml
 ```
 
 The `--lgtm-version` flag remains available for selecting the
-`grafana/otel-lgtm` image version used by the builtin Compose fixture.
+`docker.io/grafana/otel-lgtm` image version used by the builtin Compose fixture.
 
 ### Case schema: version 2 → 3
 

--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -24,6 +24,9 @@ removed. For one-off help migrating old cases, use:
 oats migrate path/to/legacy.yaml
 ```
 
+The `--lgtm-version` flag remains available for selecting the
+`grafana/otel-lgtm` image version used by the builtin Compose fixture.
+
 ### Case schema: version 2 → 3
 
 The case-yaml assertion shape changed with the gcx-driven runner, and the schema

--- a/docs/case-reference.md
+++ b/docs/case-reference.md
@@ -114,11 +114,11 @@ they need separate app deployments.
 Set exactly one of three nested blocks; the block you set selects how the stack
 is stood up (there is no separate `type` field):
 
-| Block     | Meaning                                                                                                                                                                           |
-| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `remote`  | point at an already-running stack (`endpoint:` / a gcx context)                                                                                                                   |
-| `compose` | OATS boots a docker-compose stack; `template` defaults to `lgtm`, booting a builtin grafana/otel-lgtm alongside your `file`/`files`. Set `template: none` to bring your own stack |
-| `k3d`     | OATS boots a k3d (k3s-in-docker) cluster                                                                                                                                          |
+| Block     | Meaning                                                                                                                                                                                       |
+| --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `remote`  | point at an already-running stack (`endpoint:` / a gcx context)                                                                                                                               |
+| `compose` | OATS boots a docker-compose stack; `template` defaults to `lgtm`, booting a builtin `docker.io/grafana/otel-lgtm` alongside your `file`/`files`. Set `template: none` to bring your own stack |
+| `k3d`     | OATS boots a k3d (k3s-in-docker) cluster                                                                                                                                                      |
 
 A `compose` fixture with no `template` defaults to `template: lgtm`, so OATS
 boots the builtin LGTM stack next to your `file`/`files`. Omit `file`/`files`
@@ -138,8 +138,9 @@ fixture:
       - LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2
 ```
 
-An explicitly set version flag takes precedence over `LGTM_IMAGE`; a fixture
-`env` value takes precedence over the process environment.
+`LGTM_IMAGE` takes precedence over the version flag because it specifies the
+complete image reference. A fixture `env` value takes precedence over the
+process environment.
 
 ```yaml
 fixture:

--- a/docs/case-reference.md
+++ b/docs/case-reference.md
@@ -135,7 +135,7 @@ digest, set `LGTM_IMAGE` in the shell or in the fixture's `env`:
 fixture:
   compose:
     env:
-      - LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2
+      - LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.29.1
 ```
 
 `LGTM_IMAGE` takes precedence over the version flag because it specifies the

--- a/docs/case-reference.md
+++ b/docs/case-reference.md
@@ -126,6 +126,21 @@ entirely (or drop the `fixture:` block altogether) to boot just the LGTM stack â
 handy for `inline-otlp` smoke tests. To skip the builtin stack, set
 `template: none` (then `file`/`files` are required).
 
+The builtin template uses `docker.io/grafana/otel-lgtm:latest`. Use
+`--lgtm-version <version>` (or `OATS_LGTM_VERSION`) to select another tag for
+the run. For a full image-reference override, including a registry mirror or
+digest, set `LGTM_IMAGE` in the shell or in the fixture's `env`:
+
+```yaml
+fixture:
+  compose:
+    env:
+      - LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2
+```
+
+An explicitly set version flag takes precedence over `LGTM_IMAGE`; a fixture
+`env` value takes precedence over the process environment.
+
 ```yaml
 fixture:
   remote:

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -119,9 +119,9 @@ fixture:
       - LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2
 ```
 
-An explicitly set `--lgtm-version` / `OATS_LGTM_VERSION` takes precedence over
-`LGTM_IMAGE`; a fixture `env` value takes precedence over the process
-environment.
+`LGTM_IMAGE` takes precedence over `--lgtm-version` /
+`OATS_LGTM_VERSION`, because it specifies the complete image reference. A
+fixture `env` value takes precedence over the process environment.
 
 GCX is resolved according to the [GCX resolution](#gcx-resolution) policy.
 
@@ -144,7 +144,7 @@ Flags:
 | `--gcx-version`             | `OATS_GCX_VERSION`                | —                                                                  | require this exact gcx version, using PATH/cache before downloading (for example, `0.4.3`) |
 | `--gcx-download`            | `OATS_GCX_DOWNLOAD`               | `auto` (`never` when mise is detected)                             | download policy for missing/incompatible GCX: `auto` or `never`                            |
 | `--gcx-context`             | `OATS_GCX_CONTEXT`                | derived                                                            | gcx context to query (otherwise derived from the fixture endpoint)                         |
-| `--lgtm-version`            | `OATS_LGTM_VERSION`               | `latest`                                                           | grafana/otel-lgtm version used by the builtin Compose fixture                              |
+| `--lgtm-version`            | `OATS_LGTM_VERSION`               | `latest`                                                           | `docker.io/grafana/otel-lgtm` version used by the builtin Compose fixture                  |
 | `--container-runtime`       | `OATS_CONTAINER_RUNTIME`          | `auto`                                                             | Compose engine: prefer Podman, or explicitly use `docker` / `podman`                       |
 | `--app-host` / `--app-port` | `OATS_APP_HOST` / `OATS_APP_PORT` | `localhost` / `8080`                                               | where to drive `input` requests when a fixture doesn't resolve the app endpoint itself     |
 | `--otlp-http`               | `OATS_OTLP_HTTP`                  | `http://localhost:4318`                                            | OTLP/HTTP base URL for the `inline-otlp` seed                                              |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -101,6 +101,28 @@ Compose fixtures use the host container engine selected by
 falls back to Docker; selecting `podman` or `docker` explicitly never silently
 falls back. k3d fixtures currently require Docker.
 
+The builtin Compose fixture uses `docker.io/grafana/otel-lgtm:latest`. Select a
+different tag with `--lgtm-version 0.12.2` or
+`OATS_LGTM_VERSION=0.12.2`. To override the entire image reference instead,
+set `LGTM_IMAGE`, either in the process environment:
+
+```sh
+LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2 oats
+```
+
+or on an individual fixture:
+
+```yaml
+fixture:
+  compose:
+    env:
+      - LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2
+```
+
+An explicitly set `--lgtm-version` / `OATS_LGTM_VERSION` takes precedence over
+`LGTM_IMAGE`; a fixture `env` value takes precedence over the process
+environment.
+
 GCX is resolved according to the [GCX resolution](#gcx-resolution) policy.
 
 Flags:
@@ -122,6 +144,7 @@ Flags:
 | `--gcx-version`             | `OATS_GCX_VERSION`                | —                                                                  | require this exact gcx version, using PATH/cache before downloading (for example, `0.4.3`) |
 | `--gcx-download`            | `OATS_GCX_DOWNLOAD`               | `auto` (`never` when mise is detected)                             | download policy for missing/incompatible GCX: `auto` or `never`                            |
 | `--gcx-context`             | `OATS_GCX_CONTEXT`                | derived                                                            | gcx context to query (otherwise derived from the fixture endpoint)                         |
+| `--lgtm-version`            | `OATS_LGTM_VERSION`               | `latest`                                                           | grafana/otel-lgtm version used by the builtin Compose fixture                              |
 | `--container-runtime`       | `OATS_CONTAINER_RUNTIME`          | `auto`                                                             | Compose engine: prefer Podman, or explicitly use `docker` / `podman`                       |
 | `--app-host` / `--app-port` | `OATS_APP_HOST` / `OATS_APP_PORT` | `localhost` / `8080`                                               | where to drive `input` requests when a fixture doesn't resolve the app endpoint itself     |
 | `--otlp-http`               | `OATS_OTLP_HTTP`                  | `http://localhost:4318`                                            | OTLP/HTTP base URL for the `inline-otlp` seed                                              |

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -102,12 +102,12 @@ falls back to Docker; selecting `podman` or `docker` explicitly never silently
 falls back. k3d fixtures currently require Docker.
 
 The builtin Compose fixture uses `docker.io/grafana/otel-lgtm:latest`. Select a
-different tag with `--lgtm-version 0.12.2` or
-`OATS_LGTM_VERSION=0.12.2`. To override the entire image reference instead,
+different tag with `--lgtm-version 0.29.1` or
+`OATS_LGTM_VERSION=0.29.1`. To override the entire image reference instead,
 set `LGTM_IMAGE`, either in the process environment:
 
 ```sh
-LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2 oats
+LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.29.1 oats
 ```
 
 or on an individual fixture:
@@ -116,7 +116,7 @@ or on an individual fixture:
 fixture:
   compose:
     env:
-      - LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.12.2
+      - LGTM_IMAGE=registry.example.com/mirror/otel-lgtm:0.29.1
 ```
 
 `LGTM_IMAGE` takes precedence over `--lgtm-version` /

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -45,8 +45,9 @@ func TestRootAndRunCommandsRegisterTheSameRunFlags(t *testing.T) {
 }
 
 func TestWithLGTMVersion(t *testing.T) {
+	t.Setenv("LGTM_IMAGE", "")
 	original := &casefile.ComposeFixture{
-		Env: []string{"LGTM_IMAGE=example.invalid/custom:lgtm", "FOO=bar"},
+		Env: []string{"FOO=bar"},
 	}
 	plan := discovery.Plan{Fixture: casefile.FixtureConfig{Compose: original}}
 
@@ -55,14 +56,13 @@ func TestWithLGTMVersion(t *testing.T) {
 		t.Fatal("withLGTMVersion mutated the discovered fixture")
 	}
 	want := []string{
-		"LGTM_IMAGE=example.invalid/custom:lgtm",
 		"FOO=bar",
 		"LGTM_IMAGE=docker.io/grafana/otel-lgtm:0.12.2",
 	}
 	if !slices.Equal(got.Fixture.Compose.Env, want) {
 		t.Fatalf("compose env = %v, want %v", got.Fixture.Compose.Env, want)
 	}
-	if len(original.Env) != 2 {
+	if len(original.Env) != 1 {
 		t.Fatalf("original compose env was mutated: %v", original.Env)
 	}
 
@@ -76,6 +76,37 @@ func TestWithLGTMVersion(t *testing.T) {
 	if got := withLGTMVersion(none, "0.12.2"); got.Fixture.Compose != none.Fixture.Compose {
 		t.Fatal("version override should not affect template=none fixtures")
 	}
+}
+
+func TestWithLGTMVersionPreservesFullImageOverride(t *testing.T) {
+	t.Run("fixture env", func(t *testing.T) {
+		compose := &casefile.ComposeFixture{
+			Env: []string{"LGTM_IMAGE=example.invalid/custom:lgtm"},
+		}
+		plan := discovery.Plan{Fixture: casefile.FixtureConfig{Compose: compose}}
+		if got := withLGTMVersion(plan, "0.12.2"); got.Fixture.Compose != compose {
+			t.Fatal("fixture LGTM_IMAGE should take precedence over the version")
+		}
+	})
+
+	t.Run("process env", func(t *testing.T) {
+		t.Setenv("LGTM_IMAGE", "example.invalid/custom:lgtm")
+		compose := &casefile.ComposeFixture{}
+		plan := discovery.Plan{Fixture: casefile.FixtureConfig{Compose: compose}}
+		if got := withLGTMVersion(plan, "0.12.2"); got.Fixture.Compose != compose {
+			t.Fatal("process LGTM_IMAGE should take precedence over the version")
+		}
+	})
+
+	t.Run("empty fixture env clears process override", func(t *testing.T) {
+		t.Setenv("LGTM_IMAGE", "example.invalid/custom:lgtm")
+		compose := &casefile.ComposeFixture{Env: []string{"LGTM_IMAGE="}}
+		plan := discovery.Plan{Fixture: casefile.FixtureConfig{Compose: compose}}
+		got := withLGTMVersion(plan, "0.12.2")
+		if got.Fixture.Compose == compose {
+			t.Fatal("empty fixture LGTM_IMAGE should allow the version override")
+		}
+	})
 }
 
 func TestRunActionRejectsMissingConfig(t *testing.T) {
@@ -144,6 +175,7 @@ expected:
 		"--timeout", "100ms",
 		"--interval", "1ms",
 		"--seed-settle", "1ns",
+		"--lgtm-version", "0.12.2",
 		"--no-cache",
 	})
 	if err := root.Execute(); err != nil {

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"slices"
 	"strings"
 	"testing"
 
@@ -30,7 +31,7 @@ func TestRootAndRunCommandsRegisterTheSameRunFlags(t *testing.T) {
 		t.Fatal("run command was not registered")
 	}
 
-	for _, name := range []string{"config", "gcx", "gcx-version", "gcx-download", "timeout", "parallel", "no-cache"} {
+	for _, name := range []string{"config", "gcx", "gcx-version", "gcx-download", "lgtm-version", "timeout", "parallel", "no-cache"} {
 		if root.Flags().Lookup(name) == nil {
 			t.Errorf("root command missing --%s", name)
 		}
@@ -40,6 +41,40 @@ func TestRootAndRunCommandsRegisterTheSameRunFlags(t *testing.T) {
 	}
 	if !root.SilenceUsage || !root.SilenceErrors || !run.SilenceUsage || !run.SilenceErrors {
 		t.Fatal("runtime commands should suppress Cobra usage and duplicate errors")
+	}
+}
+
+func TestWithLGTMVersion(t *testing.T) {
+	original := &casefile.ComposeFixture{
+		Env: []string{"LGTM_IMAGE=example.invalid/custom:lgtm", "FOO=bar"},
+	}
+	plan := discovery.Plan{Fixture: casefile.FixtureConfig{Compose: original}}
+
+	got := withLGTMVersion(plan, "0.12.2")
+	if got.Fixture.Compose == original {
+		t.Fatal("withLGTMVersion mutated the discovered fixture")
+	}
+	want := []string{
+		"LGTM_IMAGE=example.invalid/custom:lgtm",
+		"FOO=bar",
+		"LGTM_IMAGE=docker.io/grafana/otel-lgtm:0.12.2",
+	}
+	if !slices.Equal(got.Fixture.Compose.Env, want) {
+		t.Fatalf("compose env = %v, want %v", got.Fixture.Compose.Env, want)
+	}
+	if len(original.Env) != 2 {
+		t.Fatalf("original compose env was mutated: %v", original.Env)
+	}
+
+	if unchanged := withLGTMVersion(plan, ""); unchanged.Fixture.Compose != original {
+		t.Fatal("empty version should leave the fixture unchanged")
+	}
+
+	none := discovery.Plan{Fixture: casefile.FixtureConfig{
+		Compose: &casefile.ComposeFixture{Template: "none", File: "compose.yml"},
+	}}
+	if got := withLGTMVersion(none, "0.12.2"); got.Fixture.Compose != none.Fixture.Compose {
+		t.Fatal("version override should not affect template=none fixtures")
 	}
 }
 

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -146,6 +146,7 @@ func addRunFlags(fs *pflag.FlagSet) {
 	fs.Duration("absent-timeout", 10*time.Second, "how long an absent assertion must stay absent")
 	fs.Duration("seed-settle", 2*time.Second, "post-seed wait before first assertion")
 	fs.String("gcx-context", "", "override the gcx --context value (otherwise derived from fixture endpoint)")
+	fs.String("lgtm-version", "latest", "version of docker.io/grafana/otel-lgtm used by the builtin Compose fixture")
 	fs.String("container-runtime", "auto", "container engine for Compose fixtures: auto | docker | podman")
 	fs.String("app-host", "localhost", "application host for driving case input requests")
 	fs.Int("app-port", 8080, "application port for driving case input requests")
@@ -403,6 +404,9 @@ func runAction(cmd *cobra.Command, args []string, verbose int, exit *int) error 
 		cacheTTLDays:       cfg.Cache.TTLDays,
 		failFast:           flagBool(fs, "fail-fast"),
 	}
+	if fs.Lookup("lgtm-version").Changed {
+		opts.lgtmVersion = flagStr(fs, "lgtm-version")
+	}
 	totalPass, totalFail, runErr := runPlans(ctx, rep, plans, opts, flagInt(fs, "parallel"))
 	if runErr != nil {
 		return runErr
@@ -514,6 +518,7 @@ type runOptions struct {
 	gcxVersion         string
 	gcxContextOverride string
 	containerRuntime   string
+	lgtmVersion        string
 	appHost            string
 	appPort            int
 	otlpHTTP           string
@@ -630,6 +635,7 @@ func runPlansParallel(parent context.Context, rep report.Reporter, plans []disco
 }
 
 func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts runOptions) groupResult {
+	plan = withLGTMVersion(plan, opts.lgtmVersion)
 	fixtureStart := emitFixtureStart(rep, plan)
 	fix, rt, err := fixture.StartWithOptions(ctx, plan, fixture.Options{ContainerRuntime: opts.containerRuntime})
 	if err != nil {
@@ -707,6 +713,22 @@ func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts
 		}
 	}
 	return groupResult{pass: groupPass, fail: groupFail}
+}
+
+// withLGTMVersion applies the legacy CLI override to the builtin LGTM Compose
+// fixture without mutating the discovered plan. An unset override preserves
+// LGTM_IMAGE values supplied by the environment or the case's fixture config.
+func withLGTMVersion(plan discovery.Plan, version string) discovery.Plan {
+	compose := plan.Fixture.Compose
+	if version == "" || compose == nil || compose.EffectiveTemplate() != "lgtm" {
+		return plan
+	}
+
+	composeCopy := *compose
+	composeCopy.Env = append(append([]string(nil), compose.Env...),
+		"LGTM_IMAGE=docker.io/grafana/otel-lgtm:"+version)
+	plan.Fixture.Compose = &composeCopy
+	return plan
 }
 
 func emitFixtureStart(rep report.Reporter, plan discovery.Plan) time.Time {

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -716,11 +716,11 @@ func runPlan(ctx context.Context, rep report.Reporter, plan discovery.Plan, opts
 }
 
 // withLGTMVersion applies the legacy CLI override to the builtin LGTM Compose
-// fixture without mutating the discovered plan. An unset override preserves
-// LGTM_IMAGE values supplied by the environment or the case's fixture config.
+// fixture without mutating the discovered plan. A full LGTM_IMAGE reference
+// supplied by the environment or the case's fixture config takes precedence.
 func withLGTMVersion(plan discovery.Plan, version string) discovery.Plan {
 	compose := plan.Fixture.Compose
-	if version == "" || compose == nil || compose.EffectiveTemplate() != "lgtm" {
+	if version == "" || compose == nil || compose.EffectiveTemplate() != "lgtm" || hasLGTMImageOverride(compose.Env) {
 		return plan
 	}
 
@@ -729,6 +729,19 @@ func withLGTMVersion(plan discovery.Plan, version string) discovery.Plan {
 		"LGTM_IMAGE=docker.io/grafana/otel-lgtm:"+version)
 	plan.Fixture.Compose = &composeCopy
 	return plan
+}
+
+func hasLGTMImageOverride(env []string) bool {
+	// Compose fixture env entries override the process environment. Walk
+	// backwards so duplicate entries have the same last-value-wins behavior as
+	// the Compose command environment.
+	for i := len(env) - 1; i >= 0; i-- {
+		key, value, _ := strings.Cut(env[i], "=")
+		if key == "LGTM_IMAGE" {
+			return value != ""
+		}
+	}
+	return os.Getenv("LGTM_IMAGE") != ""
 }
 
 func emitFixtureStart(rep report.Reporter, plan discovery.Plan) time.Time {


### PR DESCRIPTION
## Summary

- restore the `--lgtm-version` run flag and its `OATS_LGTM_VERSION` equivalent
- apply the selected tag to the builtin `docker.io/grafana/otel-lgtm` Compose fixture
- preserve full-image overrides through `LGTM_IMAGE`
- document both configuration paths and their precedence

## Why

The v3 CLI rewrite removed the `--lgtm-version` flag that was available in OATs 0.7.0, even though selecting an LGTM version remains useful for reproducible acceptance tests. The underlying builtin fixture already supports `LGTM_IMAGE`, so this restores the compatible version-only interface without removing the newer full-image override.

A full `LGTM_IMAGE` reference takes precedence over `--lgtm-version` / `OATS_LGTM_VERSION`. When `LGTM_IMAGE` is not configured, the version-only interface selects a tag from the builtin `docker.io/grafana/otel-lgtm` image.

## Validation

- `mise run lint:fix`
- `mise run lint`
- `mise run test`
- `mise run build`
- verified `go run . --help` lists `--lgtm-version`

