### PR TITLE
fix(migrate): preserve source line endings

### DIFF
--- a/internal/legacyyaml/migrate/migrate.go
+++ b/internal/legacyyaml/migrate/migrate.go
@@ -32,11 +32,25 @@ func marshalYAML(v any) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
+// preserveLineEndings converts generated YAML to CRLF when the source file
+// uses CRLF. YAML encoders always emit LF, but an in-place migration should
+// not create a whole-file diff solely because of line endings.
+func preserveLineEndings(source, generated []byte) []byte {
+	if bytes.Contains(source, []byte("\r\n")) {
+		return bytes.ReplaceAll(generated, []byte("\n"), []byte("\r\n"))
+	}
+	return generated
+}
+
 // ConvertFile reads one legacy OATS yaml file and returns a best-effort
 // current-format case yaml plus any warnings about dropped or lossy fields.
 // The migrated case carries its own case-local fixture: block, so the output
 // is self-contained.
 func ConvertFile(path string) ([]byte, []string, error) {
+	source, err := os.ReadFile(path)
+	if err != nil {
+		return nil, nil, err
+	}
 	def, err := legacyyaml.LoadTestCaseDefinition(path)
 	if err != nil {
 		return nil, nil, err
@@ -52,7 +66,7 @@ func ConvertFile(path string) ([]byte, []string, error) {
 	if err != nil {
 		return nil, warnings, err
 	}
-	return out, warnings, nil
+	return preserveLineEndings(source, out), warnings, nil
 }
 
 // TreeResult reports the outcome of a directory ("project") migration.
@@ -92,6 +106,10 @@ func ConvertTree(dir string) (*TreeResult, error) {
 		}
 		seen[tc.Path] = true
 
+		source, err := os.ReadFile(tc.Path)
+		if err != nil {
+			return nil, fmt.Errorf("read %s: %w", tc.Path, err)
+		}
 		c, warnings, err := ConvertDefinition(tc.Definition, deriveName(tc.Path))
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", tc.Path, err)
@@ -100,6 +118,7 @@ func ConvertTree(dir string) (*TreeResult, error) {
 		if err != nil {
 			return nil, fmt.Errorf("%s: %w", tc.Path, err)
 		}
+		out = preserveLineEndings(source, out)
 		if err := os.WriteFile(tc.Path, out, 0o644); err != nil {
 			return nil, fmt.Errorf("write %s: %w", tc.Path, err)
 		}

--- a/internal/legacyyaml/migrate/migrate_test.go
+++ b/internal/legacyyaml/migrate/migrate_test.go
@@ -1,6 +1,7 @@
 package migrate
 
 import (
+	"bytes"
 	"os"
 	"path/filepath"
 	"strings"
@@ -117,6 +118,25 @@ func TestConvertFile_RendersYAML(t *testing.T) {
 		if !strings.Contains(text, want) {
 			fatalf(t, "expected migrated yaml to contain %q:\n%s", want, text)
 		}
+	}
+}
+
+func TestConvertFile_PreservesCRLFLineEndings(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "legacy.oats.yaml")
+	source := "oats-schema-version: 2\r\nexpected:\r\n  custom-checks:\r\n    - script: ./verify.sh\r\n"
+	if err := os.WriteFile(path, []byte(source), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	out, _, err := ConvertFile(path)
+	if err != nil {
+		t.Fatalf("ConvertFile: %v", err)
+	}
+	if bytes.Contains(bytes.ReplaceAll(out, []byte("\r\n"), nil), []byte("\n")) {
+		t.Fatalf("migrated YAML contains bare LF line endings:\n%q", out)
+	}
+	if !bytes.Contains(out, []byte("\r\n")) {
+		t.Fatalf("migrated YAML does not contain CRLF line endings:\n%q", out)
 	}
 }
 
@@ -477,6 +497,13 @@ expected:
 	if _, err := casefile.Load(minimalCase); err != nil {
 		fatalf(t, "minimal case should be v3 after migration: %v", err)
 	}
+	composeOut, err := os.ReadFile(composeCase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(composeOut, []byte("\r\n")) {
+		t.Fatal("LF source unexpectedly migrated with CRLF line endings")
+	}
 
 	// The generated config must list both cases as explicit relative paths.
 	configPath := filepath.Join(dir, "oats-config.yaml")
@@ -495,6 +522,39 @@ expected:
 		if cfg.Cases[i] != w {
 			fatalf(t, "expected sorted explicit case %q at %d, got %v", w, i, cfg.Cases)
 		}
+	}
+}
+
+func TestConvertTree_PreservesEachCaseLineEndings(t *testing.T) {
+	dir := t.TempDir()
+	crlfPath := filepath.Join(dir, "crlf.oats.yaml")
+	crlf := "oats-schema-version: 2\r\nexpected:\r\n  custom-checks:\r\n    - script: ./verify.sh\r\n"
+	if err := os.WriteFile(crlfPath, []byte(crlf), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	lfPath := filepath.Join(dir, "lf.oats.yaml")
+	lf := "oats-schema-version: 2\nexpected:\n  custom-checks:\n    - script: ./verify.sh\n"
+	if err := os.WriteFile(lfPath, []byte(lf), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := ConvertTree(dir); err != nil {
+		t.Fatalf("ConvertTree: %v", err)
+	}
+
+	crlfOut, err := os.ReadFile(crlfPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(bytes.ReplaceAll(crlfOut, []byte("\r\n"), nil), []byte("\n")) {
+		t.Fatalf("CRLF case contains bare LF line endings:\n%q", crlfOut)
+	}
+	lfOut, err := os.ReadFile(lfPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if bytes.Contains(lfOut, []byte("\r\n")) {
+		t.Fatalf("LF case contains CRLF line endings:\n%q", lfOut)
 	}
 }
 


### PR DESCRIPTION
## What changed

- preserve CRLF line endings when migrating an individual schema v2 case
- preserve each source case's line-ending style during directory migrations
- add regression coverage for CRLF and mixed LF/CRLF case trees

## Why

The YAML encoder always emits LF, so migrating a CRLF schema v2 file changed every line ending in addition to changing the schema. The migration now detects CRLF in each source file and applies that style to the generated YAML.

## Impact

Users migrating schema v2 cases keep the original line-ending style, avoiding unnecessary whole-file diffs.

## Validation

- `mise run test`
- `mise run lint`
