### PR TITLE
fix(cli): restore positional config discovery

### DIFF
--- a/UPGRADING.md
+++ b/UPGRADING.md
@@ -27,6 +27,16 @@ oats migrate path/to/legacy.yaml
 The `--lgtm-version` flag remains available for selecting the
 `docker.io/grafana/otel-lgtm` image version used by the builtin Compose fixture.
 
+Existing commands that pass a project directory can keep doing so. After
+creating `oats-config.yaml` in that directory, OATS infers its name:
+
+```sh
+oats --lgtm-version="${LGTM_VERSION}" --timeout=5m ./tests/acceptance
+```
+
+An explicit `--config ./tests/acceptance/oats-config.yaml` is also supported,
+but is not required for this migration.
+
 ### Case schema: version 2 → 3
 
 The case-yaml assertion shape changed with the gcx-driven runner, and the schema

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -13,8 +13,14 @@ file instead.
 For compatibility with directory-based invocations, if that search finds no
 config, `oats <project-dir>` loads `<project-dir>/oats-config.yaml`. A single
 positional config file works too. This means CI does not need to replace an
-existing `oats ./path/to/project` command with `oats --config
-./path/to/project/oats-config.yaml` when migrating the project.
+existing invocation:
+
+```sh
+oats ./path/to/project
+```
+
+with `oats --config ./path/to/project/oats-config.yaml` when migrating the
+project.
 
 ## GCX resolution
 

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -10,6 +10,12 @@ current directory and then each parent directory (like `git`), so you can run
 `oats` from anywhere inside a project. Pass `--config <path>` to use a specific
 file instead.
 
+For compatibility with directory-based invocations, if that search finds no
+config, `oats <project-dir>` loads `<project-dir>/oats-config.yaml`. A single
+positional config file works too. This means CI does not need to replace an
+existing `oats ./path/to/project` command with `oats --config
+./path/to/project/oats-config.yaml` when migrating the project.
+
 ## GCX resolution
 
 Release and mise-built `oats` binaries contain the minimum gcx version pinned
@@ -78,10 +84,13 @@ override the default.
 Run the cases. Bare `oats` is an implicit `run`; the explicit `run` subcommand is
 identical. With no positional args every case in the config runs; positional
 **paths** (files or directories) restrict the run to cases at or under them —
-they scope *which* cases run, they do not change where the config loads from.
+they normally scope *which* cases run. If config discovery from the current
+directory fails, a single positional argument instead selects the config as
+described above.
 
 ```sh
 oats                              # run every case
+oats ./tests/acceptance            # load ./tests/acceptance/oats-config.yaml
 oats payments/                    # only cases under payments/
 oats payments/checkout/           # only cases under payments/checkout/
 oats --tags traces                # filter by tag

--- a/docs/cli.md
+++ b/docs/cli.md
@@ -12,7 +12,7 @@ file instead.
 
 For compatibility with directory-based invocations, if that search finds no
 config, `oats <project-dir>` loads `<project-dir>/oats-config.yaml`. A single
-positional config file works too. This means CI does not need to replace an
+positional config file works too. This means existing usage does not need to replace an
 existing invocation:
 
 ```sh
@@ -96,7 +96,7 @@ described above.
 
 ```sh
 oats                              # run every case
-oats ./tests/acceptance            # load ./tests/acceptance/oats-config.yaml
+oats ./tests/acceptance           # load ./tests/acceptance/oats-config.yaml
 oats payments/                    # only cases under payments/
 oats payments/checkout/           # only cases under payments/checkout/
 oats --tags traces                # filter by tag

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -331,6 +331,42 @@ func TestResolveRunConfigPathKeepsFiltersWhenConfigIsDiscovered(t *testing.T) {
 	}
 }
 
+func TestResolveRunConfigPathReportsInvalidPositionalArgument(t *testing.T) {
+	cwd := t.TempDir()
+	t.Chdir(cwd)
+
+	newFlags := func() *pflag.FlagSet {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("config", "oats-config.yaml", "config")
+		return fs
+	}
+
+	for name, arg := range map[string]string{
+		"missing path":             filepath.Join(cwd, "missing"),
+		"directory without config": t.TempDir(),
+	} {
+		t.Run(name, func(t *testing.T) {
+			_, _, err := resolveRunConfigPath(newFlags(), []string{arg})
+			if err == nil {
+				t.Fatal("resolveRunConfigPath unexpectedly succeeded")
+			}
+			for _, want := range []string{"no oats-config.yaml found", "cannot use positional config path", arg} {
+				if !strings.Contains(err.Error(), want) {
+					t.Errorf("error %q does not contain %q", err, want)
+				}
+			}
+		})
+	}
+
+	_, paths, err := resolveRunConfigPath(newFlags(), []string{"one", "two"})
+	if err == nil || !strings.Contains(err.Error(), "no oats-config.yaml found") {
+		t.Fatalf("multi-path error = %v, want config discovery error", err)
+	}
+	if !slices.Equal(paths, []string{"one", "two"}) {
+		t.Fatalf("paths = %v, want original positional paths", paths)
+	}
+}
+
 func TestCLIListMigrateAndCacheCommands(t *testing.T) {
 	dir := t.TempDir()
 	config := filepath.Join(dir, "oats-config.yaml")

--- a/internal/cli/commands_test.go
+++ b/internal/cli/commands_test.go
@@ -271,6 +271,66 @@ func TestCLIConfigAndSmallHelpers(t *testing.T) {
 	}
 }
 
+func TestResolveRunConfigPathFromPositionalArgument(t *testing.T) {
+	cwd := t.TempDir()
+	project := filepath.Join(t.TempDir(), "project")
+	if err := os.Mkdir(project, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	config := filepath.Join(project, "oats-config.yaml")
+	if err := os.WriteFile(config, []byte("meta:\n  version: 3\ncases: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(cwd)
+
+	newFlags := func() *pflag.FlagSet {
+		fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+		fs.String("config", "oats-config.yaml", "config")
+		return fs
+	}
+
+	for name, arg := range map[string]string{
+		"directory": project,
+		"file":      config,
+	} {
+		t.Run(name, func(t *testing.T) {
+			got, paths, err := resolveRunConfigPath(newFlags(), []string{arg})
+			if err != nil {
+				t.Fatalf("resolveRunConfigPath: %v", err)
+			}
+			if got != config {
+				t.Fatalf("config = %q, want %q", got, config)
+			}
+			if paths != nil {
+				t.Fatalf("paths = %v, want positional config argument to be consumed", paths)
+			}
+		})
+	}
+}
+
+func TestResolveRunConfigPathKeepsFiltersWhenConfigIsDiscovered(t *testing.T) {
+	dir := t.TempDir()
+	config := filepath.Join(dir, "oats-config.yaml")
+	if err := os.WriteFile(config, []byte("meta:\n  version: 3\ncases: []\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Chdir(dir)
+
+	fs := pflag.NewFlagSet("test", pflag.ContinueOnError)
+	fs.String("config", "oats-config.yaml", "config")
+	args := []string{"cases"}
+	got, paths, err := resolveRunConfigPath(fs, args)
+	if err != nil {
+		t.Fatalf("resolveRunConfigPath: %v", err)
+	}
+	if got != config {
+		t.Fatalf("config = %q, want %q", got, config)
+	}
+	if !slices.Equal(paths, args) {
+		t.Fatalf("paths = %v, want %v", paths, args)
+	}
+}
+
 func TestCLIListMigrateAndCacheCommands(t *testing.T) {
 	dir := t.TempDir()
 	config := filepath.Join(dir, "oats-config.yaml")

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -13,8 +13,10 @@
 //	oats version           print the version
 //
 // The config (oats-config.yaml) is found in the current directory or any parent
-// unless --config is given. Positional paths (e.g. `oats examples/`) restrict the
-// run to cases at or under them.
+// unless --config is given. When none is found, a single positional file is
+// treated as the config, or oats-config.yaml is inferred from a positional
+// directory. Otherwise positional paths restrict the run to cases at or under
+// them.
 //
 // Run flags (subset):
 //
@@ -96,8 +98,9 @@ func newRootCmd(exit *int) *cobra.Command {
 		Short: "OpenTelemetry Acceptance Tests — the gcx-driven runner",
 		Long: "OpenTelemetry Acceptance Tests — the gcx-driven runner.\n\n" +
 			"With no subcommand, oats runs the cases in oats-config.yaml (found in the\n" +
-			"current directory or any parent). Optional positional paths scope the run to\n" +
-			"cases at or under them, e.g. `oats examples/` or `oats examples/go/oats-case.yaml`.",
+			"current directory or any parent). If no config is found there, a single\n" +
+			"positional file or project directory selects it. Otherwise positional paths\n" +
+			"scope the run to cases at or under them.",
 		// Do not print full command usage for runtime failures such as failed
 		// assertions or unreachable backends. Those are not CLI syntax errors.
 		SilenceUsage: true,
@@ -176,8 +179,9 @@ func newRunCmd(verbose, exit *int) *cobra.Command {
 		Short: "Run the cases in oats-config.yaml (default when no subcommand is given)",
 		Long: "Run the cases declared by oats-config.yaml.\n\n" +
 			"The config is found in the current directory or any parent (override with\n" +
-			"--config). Optional positional paths scope the run to cases at or under those\n" +
-			"files/directories, e.g. `oats run examples/` runs only the cases under examples/.",
+			"--config). If none is found, pass its file or project directory as the single\n" +
+			"positional argument. Otherwise positional paths scope the run to cases at or\n" +
+			"under those files/directories.",
 		// Runtime failures should print the concise error/report, not usage.
 		SilenceUsage: true,
 		// Let Run() own error printing and exit-code mapping. Without this, Cobra
@@ -318,8 +322,9 @@ func migrateAction(path string) error {
 }
 
 // runAction is the shared implementation behind the implicit-run root and the
-// explicit `run` subcommand. Positional args are file/dir paths that scope which
-// cases run; the config is resolved from cwd (walking up), independent of them.
+// explicit `run` subcommand. Positional args normally scope which cases run.
+// When config discovery from cwd fails, a single positional arg instead selects
+// the config (with oats-config.yaml inferred when the arg is a directory).
 func runAction(cmd *cobra.Command, args []string, verbose int, exit *int) error {
 	fs := cmd.Flags()
 
@@ -331,7 +336,7 @@ func runAction(cmd *cobra.Command, args []string, verbose int, exit *int) error 
 		return migrateAction(migratePath)
 	}
 
-	configPath, err := resolveConfigPath(fs)
+	configPath, pathArgs, err := resolveRunConfigPath(fs, args)
 	if err != nil {
 		return err
 	}
@@ -340,7 +345,7 @@ func runAction(cmd *cobra.Command, args []string, verbose int, exit *int) error 
 		return err
 	}
 
-	paths, err := absArgs(args)
+	paths, err := absArgs(pathArgs)
 	if err != nil {
 		return err
 	}
@@ -839,6 +844,30 @@ func resolveConfigPath(fs *pflag.FlagSet) (string, error) {
 		}
 		dir = parent
 	}
+}
+
+// resolveRunConfigPath adds a compatibility fallback to normal config
+// discovery: when cwd and its parents have no config, a single positional
+// argument may name the config file or its containing project directory. The
+// consumed argument is not also used as a case-path filter.
+func resolveRunConfigPath(fs *pflag.FlagSet, args []string) (string, []string, error) {
+	configPath, discoveryErr := resolveConfigPath(fs)
+	if discoveryErr == nil || len(args) != 1 {
+		return configPath, args, discoveryErr
+	}
+
+	candidate := args[0]
+	info, err := os.Stat(candidate)
+	if err != nil {
+		return "", args, discoveryErr
+	}
+	if info.IsDir() {
+		candidate = filepath.Join(candidate, flagStr(fs, "config"))
+	}
+	if _, err := os.Stat(candidate); err != nil {
+		return "", args, discoveryErr
+	}
+	return candidate, nil, nil
 }
 
 // absArgs cleans positional path args to absolute paths (relative to cwd) for

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -859,13 +859,13 @@ func resolveRunConfigPath(fs *pflag.FlagSet, args []string) (string, []string, e
 	candidate := args[0]
 	info, err := os.Stat(candidate)
 	if err != nil {
-		return "", args, discoveryErr
+		return "", args, fmt.Errorf("%w; cannot use positional config path %q: %v", discoveryErr, candidate, err)
 	}
 	if info.IsDir() {
 		candidate = filepath.Join(candidate, flagStr(fs, "config"))
 	}
 	if _, err := os.Stat(candidate); err != nil {
-		return "", args, discoveryErr
+		return "", args, fmt.Errorf("%w; cannot use positional config path %q: %v", discoveryErr, candidate, err)
 	}
 	return candidate, nil, nil
 }


### PR DESCRIPTION
## Summary

- restore support for passing an OATS project directory as the positional argument
- infer `oats-config.yaml` from that directory when normal config discovery finds nothing
- accept a positional config file and preserve existing path-filter behavior when a config is already discovered
- document the migration-compatible invocation in the CLI reference and upgrading guide

## Why

The v3 CLI required callers whose OATS project is below the working directory to replace an existing command such as `oats ./tests/acceptance` with an explicit `--config ./tests/acceptance/oats-config.yaml`. The positional directory already identifies the project, so requiring the expanded config path is unnecessary migration churn.

## Validation

- `mise run lint`
- `mise run test`
