### PR TITLE
feat: support one-shot Compose inputs

### DIFF
--- a/.github/renovate-tracked-deps.json
+++ b/.github/renovate-tracked-deps.json
@@ -134,6 +134,11 @@
         "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen"
       ]
     },
+    "tests/e2e/cases/fixture/compose-command-input/files/docker-compose.oats.yml": {
+      "docker-compose": [
+        "ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen"
+      ]
+    },
     "tests/e2e/cases/fixture/compose-logs-fail/files/docker-compose.oats.yml": {
       "docker-compose": [
         "alpine"

--- a/README.md
+++ b/README.md
@@ -131,8 +131,18 @@ expected:
 ```
 
 `oats` boots the app next to a throwaway Grafana LGTM stack (the default fixture —
-no `template: lgtm` needed), drives `/rolldice`, and retries each assertion until
-it passes or times out.
+no `template: lgtm` needed), drives `/rolldice` once, and retries each telemetry
+query until its assertion passes or times out.
+
+One-shot CLIs and batch jobs can run directly as a service in the Compose
+fixture, without an HTTP shim:
+
+```yaml
+input:
+  - compose:
+      service: app
+      command: [mise, run, hello]
+```
 
 No app of your own yet? A case can seed telemetry directly with
 `seed: {type: inline-otlp}` and skip the app entirely — see

--- a/casefile/case.go
+++ b/casefile/case.go
@@ -181,17 +181,26 @@ type SeedMetric struct {
 	Value   int64  `yaml:"value"`
 }
 
-// Input drives the application under test so telemetry is emitted before
-// assertions run. It keeps the HTTP request shape unchanged from the legacy
-// format (schema version 2).
+// Input drives the application under test once, before assertions begin.
+// HTTP inputs keep the request shape from the legacy format (schema version 2);
+// Compose inputs run a one-shot command in a service from the case's fixture.
 type Input struct {
 	Scheme  string            `yaml:"scheme,omitempty"`
 	Host    string            `yaml:"host,omitempty"`
 	Method  string            `yaml:"method,omitempty"`
-	Path    string            `yaml:"path"`
+	Path    string            `yaml:"path,omitempty"`
 	Headers map[string]string `yaml:"headers,omitempty"`
 	Body    string            `yaml:"body,omitempty"`
 	Status  string            `yaml:"status,omitempty"`
+	Compose *ComposeInput     `yaml:"compose,omitempty"`
+}
+
+// ComposeInput runs a service as a one-shot Compose command. Command is passed
+// as an argv list, without a shell; use ["sh", "-c", "..."] when shell syntax
+// is intentionally required.
+type ComposeInput struct {
+	Service string   `yaml:"service"`
+	Command []string `yaml:"command"`
 }
 
 // Expected groups per-signal assertion blocks. A case may omit any signal it
@@ -446,8 +455,29 @@ func (c *Case) Validate() error {
 		return fmt.Errorf("expected: at least one assertion required (signal or custom-check)")
 	}
 	for i, in := range c.Input {
-		if in.Path == "" {
+		hasHTTP := in.Path != "" || in.Scheme != "" || in.Host != "" || in.Method != "" || len(in.Headers) > 0 || in.Body != "" || in.Status != ""
+		hasCompose := in.Compose != nil
+		if hasHTTP == hasCompose {
+			return fmt.Errorf("input[%d]: set exactly one of path or compose", i)
+		}
+		if hasHTTP && in.Path == "" {
 			return fmt.Errorf("input[%d].path: required, non-empty", i)
+		}
+		if hasCompose {
+			if c.Fixture != nil && c.Fixture.Kind() != "" && c.Fixture.Kind() != "compose" {
+				return fmt.Errorf("input[%d].compose: requires a Compose fixture", i)
+			}
+			if strings.TrimSpace(in.Compose.Service) == "" {
+				return fmt.Errorf("input[%d].compose.service: required, non-empty", i)
+			}
+			if len(in.Compose.Command) == 0 {
+				return fmt.Errorf("input[%d].compose.command: required, non-empty", i)
+			}
+			for j, arg := range in.Compose.Command {
+				if arg == "" {
+					return fmt.Errorf("input[%d].compose.command[%d]: must be non-empty", i, j)
+				}
+			}
 		}
 	}
 	for i := range c.Expected.Traces {

--- a/casefile/case.go
+++ b/casefile/case.go
@@ -455,7 +455,7 @@ func (c *Case) Validate() error {
 		return fmt.Errorf("expected: at least one assertion required (signal or custom-check)")
 	}
 	for i, in := range c.Input {
-		hasHTTP := in.Path != "" || in.Scheme != "" || in.Host != "" || in.Method != "" || len(in.Headers) > 0 || in.Body != "" || in.Status != ""
+		hasHTTP := in.Path != "" || in.Scheme != "" || in.Host != "" || in.Method != "" || in.Headers != nil || in.Body != "" || in.Status != ""
 		hasCompose := in.Compose != nil
 		if hasHTTP == hasCompose {
 			return fmt.Errorf("input[%d]: set exactly one of path or compose", i)
@@ -474,7 +474,7 @@ func (c *Case) Validate() error {
 				return fmt.Errorf("input[%d].compose.command: required, non-empty", i)
 			}
 			for j, arg := range in.Compose.Command {
-				if arg == "" {
+				if strings.TrimSpace(arg) == "" {
 					return fmt.Errorf("input[%d].compose.command[%d]: must be non-empty", i, j)
 				}
 			}

--- a/casefile/case_test.go
+++ b/casefile/case_test.go
@@ -49,6 +49,64 @@ expected:
 	}
 }
 
+func TestParse_ComposeInput(t *testing.T) {
+	c, err := Parse([]byte(`
+name: one-shot cli emits telemetry
+fixture:
+  compose:
+    file: compose.yml
+input:
+  - compose:
+      service: app
+      command: [mise, run, hello]
+expected:
+  logs:
+    - logql: '{service_name="mise"}'
+      contains: hello
+`))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if len(c.Input) != 1 || c.Input[0].Compose == nil {
+		t.Fatalf("Input: %+v", c.Input)
+	}
+	if got := c.Input[0].Compose; got.Service != "app" || strings.Join(got.Command, " ") != "mise run hello" {
+		t.Fatalf("Compose input: %+v", got)
+	}
+}
+
+func TestValidate_InputKind(t *testing.T) {
+	base := Case{Name: "input validation", Expected: Expected{Logs: []LogAssertion{{LogQL: "{}"}}}}
+	tests := []struct {
+		name  string
+		input Input
+		want  string
+	}{
+		{name: "empty", input: Input{}, want: "set exactly one"},
+		{name: "mixed", input: Input{Path: "/run", Compose: &ComposeInput{Service: "app", Command: []string{"run"}}}, want: "set exactly one"},
+		{name: "http path", input: Input{Method: "POST"}, want: ".path: required"},
+		{name: "compose service", input: Input{Compose: &ComposeInput{Command: []string{"run"}}}, want: ".compose.service: required"},
+		{name: "compose command", input: Input{Compose: &ComposeInput{Service: "app"}}, want: ".compose.command: required"},
+		{name: "empty argument", input: Input{Compose: &ComposeInput{Service: "app", Command: []string{"run", ""}}}, want: ".compose.command[1]"},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			c := base
+			c.Input = []Input{tc.input}
+			if err := c.Validate(); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Validate error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+
+	remote := base
+	remote.Fixture = &FixtureConfig{Remote: &RemoteFixture{Endpoint: "http://example.test:4318"}}
+	remote.Input = []Input{{Compose: &ComposeInput{Service: "app", Command: []string{"run"}}}}
+	if err := remote.Validate(); err == nil || !strings.Contains(err.Error(), "requires a Compose fixture") {
+		t.Fatalf("remote Compose input error = %v", err)
+	}
+}
+
 func TestParse_InlineOTLPSeed(t *testing.T) {
 	src := []byte(`
 name: gcx returns seeded trace

--- a/casefile/case_test.go
+++ b/casefile/case_test.go
@@ -85,9 +85,11 @@ func TestValidate_InputKind(t *testing.T) {
 		{name: "empty", input: Input{}, want: "set exactly one"},
 		{name: "mixed", input: Input{Path: "/run", Compose: &ComposeInput{Service: "app", Command: []string{"run"}}}, want: "set exactly one"},
 		{name: "http path", input: Input{Method: "POST"}, want: ".path: required"},
+		{name: "empty headers imply http", input: Input{Headers: map[string]string{}}, want: ".path: required"},
 		{name: "compose service", input: Input{Compose: &ComposeInput{Command: []string{"run"}}}, want: ".compose.service: required"},
 		{name: "compose command", input: Input{Compose: &ComposeInput{Service: "app"}}, want: ".compose.command: required"},
 		{name: "empty argument", input: Input{Compose: &ComposeInput{Service: "app", Command: []string{"run", ""}}}, want: ".compose.command[1]"},
+		{name: "whitespace argument", input: Input{Compose: &ComposeInput{Service: "app", Command: []string{"run", " \t"}}}, want: ".compose.command[1]"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/case-reference.md
+++ b/docs/case-reference.md
@@ -217,6 +217,51 @@ seed:
 > Assert profiles against an app-backed fixture that produces them (e.g. an eBPF
 > profiler or a pyroscope-instrumented app).
 
+## Inputs
+
+Inputs drive an app-backed fixture **once per case**, before OATS starts polling
+the observability backend. Assertion retries repeat only the `gcx` query; they do
+not repeat side effects or produce duplicate telemetry.
+
+An HTTP input sends a request to the fixture's application endpoint:
+
+```yaml
+input:
+  - path: /rolldice       # required; method defaults to GET
+    method: POST
+    headers:
+      Content-Type: application/json
+    body: '{"rolls": 5}'
+    status: "201"         # expected status; defaults to 200
+```
+
+A Compose input runs a service as a one-shot container in the active Compose
+project:
+
+```yaml
+input:
+  - compose:
+      service: app
+      command: [mise, run, hello]
+```
+
+`command` is an argument list and does not implicitly use a shell. Use
+`[sh, -c, "first-command && second-command"]` when shell evaluation is
+intentional. OATS runs `compose build SERVICE` followed by
+`compose run --rm SERVICE ...`, so the command inherits the service's image,
+environment, volumes, and fixture network.
+Compose inputs are not supported by `remote` or `k3d` fixtures.
+
+Keep a command-only service out of the fixture's initial `compose up` by placing
+it behind a profile. Explicitly running the service still activates it:
+
+```yaml
+services:
+  app:
+    build: .
+    profiles: [oats-input]
+```
+
 ## Assertions
 
 Every signal block under `expected` shares one assertion vocabulary, plus a
@@ -339,8 +384,9 @@ echo "custom check ok"
   publish **no fixed host ports**. An app-seed compose group qualifies when its
   app binds an *ephemeral* host port (`127.0.0.1::<port>`) and the fixture sets
   `app_service` + `app_port` so OATS can discover the published port; an app-seed
-  group without `app_service`, or any compose file that binds a fixed host port,
-  runs serially. k3d groups always run serially.
+  group with HTTP inputs but without `app_service`, or any compose file that
+  binds a fixed host port, runs serially. Compose-command inputs need no
+  published app port. k3d groups always run serially.
 - **Memory, not CPU, is the limit for compose parallelism.** Each parallel
   `template = "lgtm"` group boots its *own* LGTM stack — a unique compose project
   with dynamically allocated host ports — so groups can neither collide on ports

--- a/fixture/compose.go
+++ b/fixture/compose.go
@@ -73,6 +73,9 @@ func startCompose(plan discovery.Plan, engine container.Engine) (Handle, Runtime
 		ComposeProject:   project,
 		ContainerRuntime: string(engine),
 	}
+	if commandHandle, ok := stack.(composeCommandHandle); ok {
+		rt.RunCompose = commandHandle.Run
+	}
 	// When the fixture manages the app (app_service + app_port), resolve the host
 	// port docker published for it. This lets the app bind an ephemeral host port
 	// (127.0.0.1::<port>) instead of a fixed one, which is what makes app-seed

--- a/fixture/fixture.go
+++ b/fixture/fixture.go
@@ -15,6 +15,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/grafana/oats/casefile"
 	"github.com/grafana/oats/discovery"
 	"github.com/grafana/oats/testhelpers/compose"
 	"github.com/grafana/oats/testhelpers/container"
@@ -70,6 +71,7 @@ type Runtime struct {
 	ParallelSafe     bool
 	ParallelDisabled string
 	ContainerRuntime string
+	RunCompose       func(context.Context, string, []string) error
 }
 
 // Handle is a booted fixture that can be torn down.
@@ -80,6 +82,10 @@ type Handle interface {
 type startableHandle interface {
 	Handle
 	Up() error
+}
+
+type composeCommandHandle interface {
+	Run(context.Context, string, []string) error
 }
 
 // Start boots the fixture declared by the plan and returns a Handle for
@@ -158,9 +164,9 @@ func SupportsParallel(plan discovery.Plan) (bool, string) {
 			// App seeds are parallel-safe only when OATS can give the app an
 			// ephemeral host port instead of a shared fixed one — which requires
 			// fixture.app_service (+ app_port) so the published port can be
-			// discovered. Without it the app falls back to the fixed --app-port
-			// and parallel suites would collide.
-			if c.Seed.EffectiveType() == "app" && !plan.Fixture.HasManagedApp() {
+			// discovered. Compose-command inputs run inside their isolated
+			// project and do not need a host port.
+			if c.Seed.EffectiveType() == "app" && hasHTTPInput(c) && !plan.Fixture.HasManagedApp() {
 				return false, "compose app-seed suites need fixture.app_service and app_port so OATS can publish an ephemeral app port; otherwise they share a fixed app port"
 			}
 		}
@@ -177,6 +183,15 @@ func SupportsParallel(plan discovery.Plan) (bool, string) {
 	default:
 		return false, "fixture type is not parallel-safe"
 	}
+}
+
+func hasHTTPInput(c *casefile.Case) bool {
+	for _, input := range c.Input {
+		if input.Compose == nil {
+			return true
+		}
+	}
+	return false
 }
 
 func startFixture(fix Handle) error {

--- a/fixture/fixture_test.go
+++ b/fixture/fixture_test.go
@@ -107,7 +107,7 @@ func TestStart_ComposeLifecycle(t *testing.T) {
 	}
 
 	sourceDir := t.TempDir()
-	fix, _, err := Start(context.Background(), discovery.Plan{
+	fix, rt, err := Start(context.Background(), discovery.Plan{
 		Name: "smoke",
 		Fixture: casefile.FixtureConfig{
 			Compose: &casefile.ComposeFixture{
@@ -134,6 +134,15 @@ func TestStart_ComposeLifecycle(t *testing.T) {
 	}
 	if gotEngine != container.Docker {
 		t.Fatalf("container engine: got %q want %q", gotEngine, container.Docker)
+	}
+	if rt.RunCompose == nil {
+		t.Fatal("compose runtime is missing command runner")
+	}
+	if err := rt.RunCompose(context.Background(), "app", []string{"mise", "run", "hello"}); err != nil {
+		t.Fatalf("RunCompose: %v", err)
+	}
+	if fake.runCalls != 1 || fake.runService != "app" || strings.Join(fake.runCommand, " ") != "mise run hello" {
+		t.Fatalf("compose command not forwarded: %+v", fake)
 	}
 	if err := fix.Close(); err != nil {
 		t.Fatalf("fixture close: %v", err)
@@ -598,7 +607,7 @@ expected:
 // app_port are set (so OATS can publish + discover an ephemeral app port) is the
 // suite safe; otherwise it would share a fixed app port with its peers.
 func TestSupportsParallel_AppSeedRequiresAppService(t *testing.T) {
-	appCase := &casefile.Case{Seed: casefile.Seed{Type: "app"}}
+	appCase := &casefile.Case{Seed: casefile.Seed{Type: "app"}, Input: []casefile.Input{{Path: "/run"}}}
 
 	// app seed, no app_service → not parallel-safe.
 	noService := discovery.Plan{
@@ -616,6 +625,20 @@ func TestSupportsParallel_AppSeedRequiresAppService(t *testing.T) {
 	}
 	if safe, reason := SupportsParallel(withService); !safe {
 		t.Fatalf("app-seed with app_service+app_port should be parallel-safe: %s", reason)
+	}
+
+	// A Compose command runs inside its fixture's isolated project and needs no
+	// published app port.
+	commandCase := &casefile.Case{
+		Seed:  casefile.Seed{Type: "app"},
+		Input: []casefile.Input{{Compose: &casefile.ComposeInput{Service: "app", Command: []string{"run"}}}},
+	}
+	commandPlan := discovery.Plan{
+		Fixture: casefile.FixtureConfig{Compose: &casefile.ComposeFixture{Template: "lgtm"}},
+		Cases:   []*casefile.Case{commandCase},
+	}
+	if safe, reason := SupportsParallel(commandPlan); !safe {
+		t.Fatalf("compose command should be parallel-safe: %s", reason)
 	}
 }
 
@@ -648,6 +671,9 @@ func writeFile(t *testing.T, dir, rel, body string) {
 type fakeHandle struct {
 	upCalls    int
 	closeCalls int
+	runCalls   int
+	runService string
+	runCommand []string
 	upErr      error
 	closeErr   error
 }
@@ -660,6 +686,13 @@ func (f *fakeHandle) Up() error {
 func (f *fakeHandle) Close() error {
 	f.closeCalls++
 	return f.closeErr
+}
+
+func (f *fakeHandle) Run(_ context.Context, service string, command []string) error {
+	f.runCalls++
+	f.runService = service
+	f.runCommand = append([]string(nil), command...)
+	return nil
 }
 
 func equalStrings(got, want []string) bool {

--- a/internal/cli/integration_test.go
+++ b/internal/cli/integration_test.go
@@ -26,15 +26,19 @@ import (
 )
 
 func TestResolveEndpoint_ComposeDefaults(t *testing.T) {
+	runCompose := func(context.Context, string, []string) error { return nil }
 	ep, err := resolveEndpoint(discovery.Plan{
 		Name:    "smoke",
 		Fixture: casefile.FixtureConfig{Compose: &casefile.ComposeFixture{Template: "lgtm"}},
-	}, fixture.Runtime{GCXConfig: "/tmp/gcx.yaml", OTLPHTTP: "http://127.0.0.1:4318"}, "", "localhost", 8080, "http://localhost:4318")
+	}, fixture.Runtime{GCXConfig: "/tmp/gcx.yaml", OTLPHTTP: "http://127.0.0.1:4318", RunCompose: runCompose}, "", "localhost", 8080, "http://localhost:4318")
 	if err != nil {
 		t.Fatalf("resolveEndpoint: %v", err)
 	}
 	if ep.GCXContext != "" || ep.GCXConfig != "/tmp/gcx.yaml" || ep.AppHost != "localhost" || ep.AppPort != 8080 || ep.OTLPHTTP != "http://127.0.0.1:4318" {
 		t.Fatalf("unexpected endpoint: %+v", ep)
+	}
+	if ep.RunCompose == nil {
+		t.Fatal("compose command runner was not forwarded")
 	}
 }
 

--- a/internal/cli/main.go
+++ b/internal/cli/main.go
@@ -491,6 +491,7 @@ func resolveEndpoint(plan discovery.Plan, rt fixture.Runtime, gcxContextOverride
 			ep.OTLPHTTP = rt.OTLPHTTP
 		}
 		ep.CustomCheckEnv = append(ep.CustomCheckEnv, rt.CustomCheckEnv...)
+		ep.RunCompose = rt.RunCompose
 	case "k3d":
 		if rt.GCXConfig != "" {
 			ep.GCXConfig = rt.GCXConfig

--- a/runner/assertions.go
+++ b/runner/assertions.go
@@ -27,9 +27,6 @@ func (r *Runner) runTrace(ctx context.Context, c *casefile.Case, a *casefile.Tra
 
 func (r *Runner) runTraceStructured(ctx context.Context, c *casefile.Case, a *casefile.TraceAssertion) bool {
 	run := func() []assert.Failure {
-		if err := r.driveInputs(c); err != nil {
-			return []assert.Failure{{Rule: "input", Detail: err.Error()}}
-		}
 		searchArgs := signalcmd.Traces(*a, 0)
 		searchCmd := signalcmd.Render(searchArgs)
 		execCtx, cancel := context.WithTimeout(ctx, r.opts.Timeout)

--- a/runner/checks.go
+++ b/runner/checks.go
@@ -20,9 +20,6 @@ import (
 
 func (r *Runner) runComposeLogCheck(ctx context.Context, c *casefile.Case, msg string) bool {
 	run := func() []assert.Failure {
-		if err := r.driveInputs(c); err != nil {
-			return []assert.Failure{{Rule: "input", Detail: err.Error()}}
-		}
 		ok, err := searchComposeLogs(ctx, r.endpoint.CustomCheckEnv, msg)
 		if err != nil {
 			return []assert.Failure{{Rule: "compose-logs", Detail: err.Error()}}
@@ -55,9 +52,6 @@ func (r *Runner) runCustomCheck(ctx context.Context, c *casefile.Case, chk *case
 		dir = filepath.Dir(c.SourcePath)
 	}
 	run := func() []assert.Failure {
-		if err := r.driveInputs(c); err != nil {
-			return []assert.Failure{{Rule: "input", Detail: err.Error()}}
-		}
 		deadlineCtx, cancel := context.WithTimeout(ctx, r.opts.Timeout)
 		defer cancel()
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -58,6 +58,10 @@ type Endpoint struct {
 	// It carries fixture-specific helpers like COMPOSE_FILE and stable local
 	// endpoint URLs.
 	CustomCheckEnv []string
+
+	// RunCompose executes a one-shot command in a service belonging to the
+	// active Compose fixture. It is nil for remote and k3d fixtures.
+	RunCompose func(context.Context, string, []string) error
 }
 
 // Options configures the polling cadence and per-case deadline. Sensible
@@ -205,9 +209,20 @@ func (r *Runner) RunCase(ctx context.Context, c *casefile.Case) bool {
 		}
 	}
 
-	// Seed.
+	// Seed and drive inputs exactly once. Assertions poll only the observability
+	// backend; repeating side-effecting inputs during each poll makes counts
+	// nondeterministic and is especially surprising for one-shot commands.
 	if err := r.seedCase(ctx, c); err != nil {
 		r.failCase(c, "seed: "+err.Error(), "")
+		r.reporter.Emit(report.Event{
+			Type:       report.EventCaseFail,
+			Case:       c.Name,
+			DurationMs: time.Since(caseStart).Milliseconds(),
+		})
+		return false
+	}
+	if err := r.driveInputs(ctx, c); err != nil {
+		r.failCase(c, "input: "+err.Error(), "")
 		r.reporter.Emit(report.Event{
 			Type:       report.EventCaseFail,
 			Case:       c.Name,
@@ -280,8 +295,7 @@ func (r *Runner) RunCase(ctx context.Context, c *casefile.Case) bool {
 func (r *Runner) seedCase(ctx context.Context, c *casefile.Case) error {
 	switch c.Seed.EffectiveType() {
 	case "app":
-		// External fixture is responsible for booting the app. Runner
-		// assumes the app is already emitting; nothing to do here.
+		// The fixture boots the app; RunCase drives its declared inputs next.
 		return nil
 	case "inline-otlp":
 		if r.seeder.OTLPEndpoint == "" {
@@ -349,9 +363,6 @@ func (r *Runner) pollAssert(
 	cmdStr := signalcmd.Render(args)
 
 	run := func() []assert.Failure {
-		if err := r.driveInputs(c); err != nil {
-			return []assert.Failure{{Rule: "input", Detail: err.Error()}}
-		}
 		execCtx, cancel := context.WithTimeout(ctx, r.opts.Timeout)
 		defer cancel()
 		res, err := r.exec.Execute(execCtx, args...)
@@ -424,16 +435,24 @@ func (r *Runner) failCase(c *casefile.Case, msg, cmd string) {
 	})
 }
 
-func (r *Runner) driveInputs(c *casefile.Case) error {
+func (r *Runner) driveInputs(ctx context.Context, c *casefile.Case) error {
 	for _, in := range c.Input {
-		if err := r.doInput(in); err != nil {
+		if err := r.doInput(ctx, in); err != nil {
 			return err
 		}
 	}
 	return nil
 }
 
-func (r *Runner) doInput(in casefile.Input) error {
+func (r *Runner) doInput(ctx context.Context, in casefile.Input) error {
+	if in.Compose != nil {
+		if r.endpoint.RunCompose == nil {
+			return fmt.Errorf("compose input requires a Compose fixture")
+		}
+		inputCtx, cancel := context.WithTimeout(ctx, r.opts.Timeout)
+		defer cancel()
+		return r.endpoint.RunCompose(inputCtx, in.Compose.Service, in.Compose.Command)
+	}
 	if in.Path == "" {
 		return nil
 	}

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -376,6 +376,31 @@ expected:
 	}
 }
 
+func TestRunCase_ComposeInputFailure(t *testing.T) {
+	r, buf := newRunner(t, &stubExec{}, Options{Timeout: 100 * time.Millisecond})
+	r.endpoint.RunCompose = func(_ context.Context, _ string, _ []string) error {
+		return errors.New("command failed")
+	}
+	c := mustParse(t, `
+name: failing one-shot cli
+input:
+  - compose:
+      service: app
+      command: ["false"]
+expected:
+  logs:
+    - logql: '{}'
+`)
+	r.reporter.Emit(report.Event{Type: report.EventRunStart})
+	if r.RunCase(context.Background(), c) {
+		t.Fatal("expected case to fail")
+	}
+	r.reporter.Emit(report.Event{Type: report.EventRunEnd})
+	if !strings.Contains(buf.String(), "input: command failed") {
+		t.Fatalf("expected input failure output, got:\n%s", buf.String())
+	}
+}
+
 func TestRunCase_InlineOTLPSeedRequiresEndpoint(t *testing.T) {
 	c := mustParse(t, `
 name: inline seed

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -307,8 +307,72 @@ expected:
 	if !ok {
 		t.Fatalf("expected case to pass")
 	}
-	if hits == 0 {
-		t.Fatalf("expected at least one input request")
+	if hits != 1 {
+		t.Fatalf("expected exactly one input request, got %d", hits)
+	}
+}
+
+func TestRunCase_DrivesInputOnlyOnceWhileAssertionsPoll(t *testing.T) {
+	var hits int
+	app := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits++
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer app.Close()
+	host, port := splitHostPort(t, app.Listener.Addr().String())
+
+	exec := &stubExec{stdout: ""}
+	r, _ := newRunner(t, exec, Options{Timeout: 20 * time.Millisecond, Interval: time.Millisecond, SeedSettleDelay: 1})
+	r.endpoint.AppHost = host
+	r.endpoint.AppPort = port
+	c := mustParse(t, `
+name: missing trace polls
+input:
+  - path: /run
+expected:
+  traces:
+    - traceql: '{}'
+      contains: ["never-found"]
+`)
+
+	if r.RunCase(context.Background(), c) {
+		t.Fatal("expected assertion to fail")
+	}
+	if len(exec.captured) < 2 {
+		t.Fatalf("expected assertion polling, got %d query calls", len(exec.captured))
+	}
+	if hits != 1 {
+		t.Fatalf("expected input once while assertion polled, got %d requests", hits)
+	}
+}
+
+func TestRunCase_ComposeInput(t *testing.T) {
+	exec := &stubExec{stdout: "hello"}
+	r, _ := newRunner(t, exec, Options{Timeout: 100 * time.Millisecond, SeedSettleDelay: 1})
+	var calls int
+	r.endpoint.RunCompose = func(_ context.Context, service string, command []string) error {
+		calls++
+		if service != "app" || strings.Join(command, " ") != "mise run hello" {
+			t.Fatalf("compose input = service %q command %#v", service, command)
+		}
+		return nil
+	}
+	c := mustParse(t, `
+name: one-shot cli
+input:
+  - compose:
+      service: app
+      command: [mise, run, hello]
+expected:
+  logs:
+    - logql: '{}'
+      contains: hello
+`)
+	if !r.RunCase(context.Background(), c) {
+		t.Fatal("expected case to pass")
+	}
+	if calls != 1 {
+		t.Fatalf("expected one Compose command, got %d", calls)
 	}
 }
 
@@ -950,17 +1014,20 @@ expected:
 
 func TestDoInputValidation(t *testing.T) {
 	r, _ := newRunner(t, &stubExec{}, Options{Timeout: time.Millisecond})
-	if err := r.doInput(casefile.Input{Path: "/health"}); err == nil || !strings.Contains(err.Error(), "application endpoint") {
+	if err := r.doInput(context.Background(), casefile.Input{Path: "/health"}); err == nil || !strings.Contains(err.Error(), "application endpoint") {
 		t.Fatalf("missing endpoint error = %v", err)
 	}
-	if err := r.doInput(casefile.Input{}); err != nil {
+	if err := r.doInput(context.Background(), casefile.Input{}); err != nil {
 		t.Fatalf("empty input should be ignored: %v", err)
+	}
+	if err := r.doInput(context.Background(), casefile.Input{Compose: &casefile.ComposeInput{Service: "app", Command: []string{"run"}}}); err == nil || !strings.Contains(err.Error(), "requires a Compose fixture") {
+		t.Fatalf("missing Compose fixture error = %v", err)
 	}
 
 	invalidStatus, _ := newRunner(t, &stubExec{}, Options{Timeout: time.Millisecond})
 	invalidStatus.endpoint.AppHost = "127.0.0.1"
 	invalidStatus.endpoint.AppPort = 1
-	if err := invalidStatus.doInput(casefile.Input{Path: "/health", Status: "created"}); err == nil || !strings.Contains(err.Error(), "not an integer") {
+	if err := invalidStatus.doInput(context.Background(), casefile.Input{Path: "/health", Status: "created"}); err == nil || !strings.Contains(err.Error(), "not an integer") {
 		t.Fatalf("invalid status error = %v", err)
 	}
 }

--- a/testhelpers/compose/compose.go
+++ b/testhelpers/compose/compose.go
@@ -145,7 +145,9 @@ func (c *Compose) runComposeContext(ctx context.Context, args ...string) error {
 	cmdArgs = append(cmdArgs, args...)
 	cmd := exec.CommandContext(ctx, c.Command, cmdArgs...)
 	cmd.Env = c.Env
-	cmd.Stdout = os.Stdout
+	// Keep command output off stdout: the CLI reserves stdout for reporter
+	// records, which must remain valid NDJSON in machine-readable mode.
+	cmd.Stdout = os.Stderr
 	cmd.Stderr = os.Stderr
 	slog.Info("Running", "command", cmd.String(), "compose_files", c.Paths)
 	return cmd.Run()

--- a/testhelpers/compose/compose.go
+++ b/testhelpers/compose/compose.go
@@ -123,6 +123,31 @@ func (c *Compose) Stop() error {
 	return c.runDocker(newCommand("stop"))
 }
 
+// Run executes a service as a one-shot container in the Compose project.
+// The service is built on demand, which lets callers keep command-only
+// services behind a profile so they are not started with the fixture.
+func (c *Compose) Run(ctx context.Context, service string, argv []string) error {
+	if err := c.runComposeContext(ctx, "build", service); err != nil {
+		return fmt.Errorf("failed to build compose service %q: %w", service, err)
+	}
+	args := append([]string{"run", "--rm", service}, argv...)
+	if err := c.runComposeContext(ctx, args...); err != nil {
+		return fmt.Errorf("failed to run compose service %q: %w", service, err)
+	}
+	return nil
+}
+
+func (c *Compose) runComposeContext(ctx context.Context, args ...string) error {
+	cmdArgs := append([]string(nil), c.DefaultArgs...)
+	cmdArgs = append(cmdArgs, args...)
+	cmd := exec.CommandContext(ctx, c.Command, cmdArgs...)
+	cmd.Env = c.Env
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	slog.Info("Running", "command", cmd.String(), "compose_files", c.Paths)
+	return cmd.Run()
+}
+
 func (c *Compose) Remove() error {
 	// `down` is supported by both Docker Compose and podman-compose. The
 	// latter does not implement Compose's `rm` command.

--- a/testhelpers/compose/compose.go
+++ b/testhelpers/compose/compose.go
@@ -130,7 +130,10 @@ func (c *Compose) Run(ctx context.Context, service string, argv []string) error 
 	if err := c.runComposeContext(ctx, "build", service); err != nil {
 		return fmt.Errorf("failed to build compose service %q: %w", service, err)
 	}
-	args := append([]string{"run", "--rm", service}, argv...)
+	// The fixture is already running. Avoid Compose recreating dependencies
+	// before the one-shot command, which can reset application readiness and
+	// disrupt instrumentation attached to the existing containers.
+	args := append([]string{"run", "--rm", "--no-deps", service}, argv...)
 	if err := c.runComposeContext(ctx, args...); err != nil {
 		return fmt.Errorf("failed to run compose service %q: %w", service, err)
 	}

--- a/testhelpers/compose/compose_test.go
+++ b/testhelpers/compose/compose_test.go
@@ -1,6 +1,7 @@
 package compose
 
 import (
+	"context"
 	"io"
 	"os"
 	"path/filepath"
@@ -42,6 +43,9 @@ esac
 	if err := c.Up(); err != nil {
 		t.Fatalf("Up: %v", err)
 	}
+	if err := c.Run(context.Background(), "app", []string{"mise", "run", "hello world"}); err != nil {
+		t.Fatalf("Run: %v", err)
+	}
 	var output strings.Builder
 	if err := c.LogsToConsumer(func(r io.ReadCloser, wg *sync.WaitGroup) {
 		defer wg.Done()
@@ -77,6 +81,8 @@ esac
 	for _, want := range []string{
 		"network prune -f --filter until=5m",
 		"-f base.yml -f override.yml up --build --detach --force-recreate",
+		"-f base.yml -f override.yml build app",
+		"-f base.yml -f override.yml run --rm app mise run hello world",
 		"-f base.yml -f override.yml logs",
 		"-f base.yml -f override.yml stop",
 		"-f base.yml -f override.yml down",

--- a/testhelpers/compose/compose_test.go
+++ b/testhelpers/compose/compose_test.go
@@ -24,6 +24,9 @@ func TestStackFilesWithRuntimeLifecycle(t *testing.T) {
 	command := filepath.Join(dir, "compose")
 	if err := os.WriteFile(command, []byte(`#!/bin/sh
 printf '%s\n' "$*" >> "$COMPOSE_TEST_ARGS"
+for arg in "$@"; do
+  printf 'arg=<%s>\n' "$arg" >> "$COMPOSE_TEST_ARGS"
+done
 case "$*" in
 *logs*)
   printf 'service ready\n'
@@ -83,6 +86,7 @@ esac
 		"-f base.yml -f override.yml up --build --detach --force-recreate",
 		"-f base.yml -f override.yml build app",
 		"-f base.yml -f override.yml run --rm app mise run hello world",
+		"arg=<hello world>",
 		"-f base.yml -f override.yml logs",
 		"-f base.yml -f override.yml stop",
 		"-f base.yml -f override.yml down",

--- a/testhelpers/compose/compose_test.go
+++ b/testhelpers/compose/compose_test.go
@@ -97,6 +97,37 @@ esac
 	}
 }
 
+func TestRunReportsBuildAndCommandFailures(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("test uses a POSIX executable")
+	}
+
+	for _, tc := range []struct {
+		name string
+		fail string
+		want string
+	}{
+		{name: "build", fail: "build", want: `failed to build compose service "app"`},
+		{name: "run", fail: "run", want: `failed to run compose service "app"`},
+	} {
+		t.Run(tc.name, func(t *testing.T) {
+			command := filepath.Join(t.TempDir(), "compose")
+			script := "#!/bin/sh\ncase \"$*\" in\n  *" + tc.fail + "*) exit 1 ;;\nesac\n"
+			if err := os.WriteFile(command, []byte(script), 0o700); err != nil {
+				t.Fatal(err)
+			}
+			c, err := StackFilesWithRuntime([]string{"compose.yml"}, nil, container.Docker)
+			if err != nil {
+				t.Fatal(err)
+			}
+			c.Command = command
+			if err := c.Run(context.Background(), "app", []string{"true"}); err == nil || !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("Run error = %v, want %q", err, tc.want)
+			}
+		})
+	}
+}
+
 func TestComposeValidationAndEnvironmentMerge(t *testing.T) {
 	if _, err := StackFilesWithRuntime(nil, nil, container.Docker); err == nil {
 		t.Fatal("expected missing compose file error")

--- a/testhelpers/compose/compose_test.go
+++ b/testhelpers/compose/compose_test.go
@@ -85,7 +85,7 @@ esac
 		"network prune -f --filter until=5m",
 		"-f base.yml -f override.yml up --build --detach --force-recreate",
 		"-f base.yml -f override.yml build app",
-		"-f base.yml -f override.yml run --rm app mise run hello world",
+		"-f base.yml -f override.yml run --rm --no-deps app mise run hello world",
 		"arg=<hello world>",
 		"-f base.yml -f override.yml logs",
 		"-f base.yml -f override.yml stop",

--- a/tests/e2e/cases/fixture/compose-command-input/files/docker-compose.oats.yml
+++ b/tests/e2e/cases/fixture/compose-command-input/files/docker-compose.oats.yml
@@ -1,0 +1,6 @@
+services:
+  telemetrygen:
+    image: ghcr.io/open-telemetry/opentelemetry-collector-contrib/telemetrygen:v0.157.0@sha256:e84b17f92d096ecf56e1dacbddf38bade4a05b72de6a316b92a38363a2bdc13f
+    # OATS explicitly runs this one-shot service as an input; the profile keeps
+    # the fixture's initial `compose up` from starting it prematurely.
+    profiles: [oats-input]

--- a/tests/e2e/cases/fixture/compose-command-input/files/oats-case.yaml
+++ b/tests/e2e/cases/fixture/compose-command-input/files/oats-case.yaml
@@ -1,0 +1,23 @@
+name: compose command input runs once
+fixture:
+  compose:
+    template: lgtm
+    file: docker-compose.oats.yml
+input:
+  - compose:
+      service: telemetrygen
+      command:
+        - traces
+        - --otlp-endpoint
+        - lgtm:4317
+        - --otlp-insecure
+        - --service
+        - oats-command-input-e2e
+        - --traces
+        - "1"
+expected:
+  traces:
+    - traceql: '{ resource.service.name = "oats-command-input-e2e" }'
+      match_spans:
+        - name: lets-go
+      count: == 1

--- a/tests/e2e/cases/fixture/compose-command-input/test.yaml
+++ b/tests/e2e/cases/fixture/compose-command-input/test.yaml
@@ -1,0 +1,16 @@
+name: compose-command-input
+tags: [fixture, compose, input]
+
+execution:
+  mode: serial
+
+run:
+  args:
+    - --timeout
+    - 90s
+    - --interval
+    - 3s
+
+expect:
+  stdout_contains:
+    - PASS 1/1


### PR DESCRIPTION
## What changed

- Add an `input.compose` case shape that builds and runs a Compose service as a one-shot command using a safe argv list.
- Drive every case input exactly once before assertion polling; retries now repeat only observability queries rather than side effects.
- Treat command-only Compose inputs as parallel-safe when they do not publish fixed host ports.
- Document command inputs and add unit and end-to-end coverage using `telemetrygen` behind a Compose profile.

```yaml
input:
  - compose:
      service: app
      command: [mise, run, hello]
```

## Why

OATS currently assumes app inputs are HTTP requests. One-shot CLIs therefore need an HTTP shim, as in the mise acceptance test, while multi-service workloads use continuously running traffic-generator sidecars, as in the docker-otel-lgtm OBI example.

A fixture-native command input lets CLI, batch-job, migration, and traffic-generation tests run inside the existing Compose network and environment without those shims.

Moving input execution outside assertion polling also fixes duplicate telemetry: the old loop repeated input side effects for every assertion and retry, which made exact-count assertions nondeterministic.

Related consumers:
- https://github.com/jdx/mise/pull/9069
- https://github.com/grafana/docker-otel-lgtm/tree/main/examples/obi

## Validation

- `mise run lint`
- `mise run test`
- `mise run build`
- `OATS_E2E_FILTER=fixture/compose-command-input mise run e2e-test` (case discovered and harness passed; container execution skipped locally because Docker/Podman is unavailable)
