### PR TITLE
feat: add opt-in HTTP input retries

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,10 @@ expected:
 no `template: lgtm` needed), drives `/rolldice` once, and retries each telemetry
 query until its assertion passes or times out.
 
+HTTP inputs can opt into bounded retries for readiness races. Retries are
+disabled by default because every attempt repeats the request and its side
+effects; see the [input reference](docs/case-reference.md#inputs).
+
 One-shot CLIs and batch jobs can run directly as a service in the Compose
 fixture, without an HTTP shim:
 

--- a/casefile/case.go
+++ b/casefile/case.go
@@ -192,7 +192,15 @@ type Input struct {
 	Headers map[string]string `yaml:"headers,omitempty"`
 	Body    string            `yaml:"body,omitempty"`
 	Status  string            `yaml:"status,omitempty"`
+	Retry   *InputRetry       `yaml:"retry,omitempty"`
 	Compose *ComposeInput     `yaml:"compose,omitempty"`
+}
+
+// InputRetry opts an HTTP input into bounded retries. Zero values inherit the
+// runner's timeout and interval.
+type InputRetry struct {
+	Timeout  time.Duration `yaml:"timeout,omitempty"`
+	Interval time.Duration `yaml:"interval,omitempty"`
 }
 
 // ComposeInput runs a service as a one-shot Compose command. Command is passed
@@ -455,13 +463,24 @@ func (c *Case) Validate() error {
 		return fmt.Errorf("expected: at least one assertion required (signal or custom-check)")
 	}
 	for i, in := range c.Input {
-		hasHTTP := in.Path != "" || in.Scheme != "" || in.Host != "" || in.Method != "" || in.Headers != nil || in.Body != "" || in.Status != ""
+		hasHTTP := in.Path != "" || in.Scheme != "" || in.Host != "" || in.Method != "" || in.Headers != nil || in.Body != "" || in.Status != "" || in.Retry != nil
 		hasCompose := in.Compose != nil
+		if hasCompose && in.Retry != nil {
+			return fmt.Errorf("input[%d].retry: only supported for HTTP inputs", i)
+		}
 		if hasHTTP == hasCompose {
 			return fmt.Errorf("input[%d]: set exactly one of path or compose", i)
 		}
 		if hasHTTP && in.Path == "" {
 			return fmt.Errorf("input[%d].path: required, non-empty", i)
+		}
+		if in.Retry != nil {
+			if in.Retry.Timeout < 0 {
+				return fmt.Errorf("input[%d].retry.timeout: must be >= 0", i)
+			}
+			if in.Retry.Interval < 0 {
+				return fmt.Errorf("input[%d].retry.interval: must be >= 0", i)
+			}
 		}
 		if hasCompose {
 			if c.Fixture != nil && c.Fixture.Kind() != "" && c.Fixture.Kind() != "compose" {

--- a/casefile/case_test.go
+++ b/casefile/case_test.go
@@ -17,6 +17,9 @@ seed:
   compose: docker-compose.app.yml
 input:
   - path: /rolldice?rolls=5
+    retry:
+      timeout: 10s
+      interval: 250ms
 expected:
   traces:
     - traceql: '{ span.http.route = "/rolldice" }'
@@ -40,6 +43,9 @@ expected:
 	}
 	if len(c.Input) != 1 || c.Input[0].Path != "/rolldice?rolls=5" {
 		t.Errorf("Input: %+v", c.Input)
+	}
+	if retry := c.Input[0].Retry; retry == nil || retry.Timeout != 10*time.Second || retry.Interval != 250*time.Millisecond {
+		t.Errorf("Input retry: %+v", retry)
 	}
 	if len(c.Expected.Traces) != 1 || c.Expected.Traces[0].TraceQL == "" {
 		t.Errorf("Expected.Traces: %+v", c.Expected.Traces)
@@ -90,6 +96,10 @@ func TestValidate_InputKind(t *testing.T) {
 		{name: "compose command", input: Input{Compose: &ComposeInput{Service: "app"}}, want: ".compose.command: required"},
 		{name: "empty argument", input: Input{Compose: &ComposeInput{Service: "app", Command: []string{"run", ""}}}, want: ".compose.command[1]"},
 		{name: "whitespace argument", input: Input{Compose: &ComposeInput{Service: "app", Command: []string{"run", " \t"}}}, want: ".compose.command[1]"},
+		{name: "retry without path", input: Input{Retry: &InputRetry{}}, want: ".path: required"},
+		{name: "retry Compose input", input: Input{Retry: &InputRetry{}, Compose: &ComposeInput{Service: "app", Command: []string{"run"}}}, want: "only supported for HTTP inputs"},
+		{name: "negative retry timeout", input: Input{Path: "/run", Retry: &InputRetry{Timeout: -1}}, want: ".retry.timeout: must be >= 0"},
+		{name: "negative retry interval", input: Input{Path: "/run", Retry: &InputRetry{Interval: -1}}, want: ".retry.interval: must be >= 0"},
 	}
 	for _, tc := range tests {
 		t.Run(tc.name, func(t *testing.T) {

--- a/docs/case-reference.md
+++ b/docs/case-reference.md
@@ -235,6 +235,25 @@ input:
     status: "201"         # expected status; defaults to 200
 ```
 
+HTTP inputs run once by default. Opt an input into bounded retries when it is
+safe to repeat, for example to tolerate an application readiness race:
+
+```yaml
+input:
+  - path: /health/readiness
+    retry: {}             # inherit the CLI --timeout and --interval
+  - path: /version
+    retry:
+      timeout: 1m
+      interval: 2s
+```
+
+Every failed request attempt is retried, including transport errors and
+unexpected HTTP statuses. The complete request, including its body, is sent
+again, so leave `retry` unset for non-idempotent or otherwise unsafe
+side-effecting inputs. `retry` applies only to HTTP inputs; Compose inputs remain
+one-shot.
+
 A Compose input runs a service as a one-shot container in the active Compose
 project:
 

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -500,12 +500,13 @@ func (r *Runner) doInput(ctx context.Context, in casefile.Input) error {
 	if interval == 0 {
 		interval = r.opts.Interval
 	}
-	inputCtx, cancel := context.WithTimeout(ctx, timeout)
-	defer cancel()
+	deadline := time.Now().Add(timeout)
 	var lastErr error
-	result := wait.Until[error](inputCtx, wait.Options{Timeout: timeout, Interval: interval}, func() []error {
-		if err := requests.DoHTTPRequestWithContext(inputCtx, url, method, headers, in.Body, status); err != nil {
-			if inputCtx.Err() == nil || lastErr == nil {
+	result := wait.Until[error](ctx, wait.Options{Timeout: timeout, Interval: interval}, func() []error {
+		attemptCtx, cancel := context.WithDeadline(ctx, deadline)
+		defer cancel()
+		if err := requests.DoHTTPRequestWithContext(attemptCtx, url, method, headers, in.Body, status); err != nil {
+			if attemptCtx.Err() == nil || lastErr == nil {
 				lastErr = err
 			}
 			return []error{err}
@@ -518,5 +519,5 @@ func (r *Runner) doInput(ctx context.Context, in casefile.Input) error {
 	if lastErr != nil {
 		return fmt.Errorf("retry exhausted after %d attempts: %w", result.Iterations, lastErr)
 	}
-	return fmt.Errorf("retry stopped after %d attempts: %w", result.Iterations, inputCtx.Err())
+	return fmt.Errorf("retry stopped after %d attempts: %w", result.Iterations, ctx.Err())
 }

--- a/runner/runner.go
+++ b/runner/runner.go
@@ -486,5 +486,37 @@ func (r *Runner) doInput(ctx context.Context, in casefile.Input) error {
 		headers["Accept"] = "application/json"
 	}
 	url := fmt.Sprintf("%s://%s:%d%s", scheme, host, r.endpoint.AppPort, in.Path)
-	return requests.DoHTTPRequestWithTimeout(url, method, headers, in.Body, status, r.opts.Timeout)
+	if in.Retry == nil {
+		inputCtx, cancel := context.WithTimeout(ctx, r.opts.Timeout)
+		defer cancel()
+		return requests.DoHTTPRequestWithContext(inputCtx, url, method, headers, in.Body, status)
+	}
+
+	timeout := in.Retry.Timeout
+	if timeout == 0 {
+		timeout = r.opts.Timeout
+	}
+	interval := in.Retry.Interval
+	if interval == 0 {
+		interval = r.opts.Interval
+	}
+	inputCtx, cancel := context.WithTimeout(ctx, timeout)
+	defer cancel()
+	var lastErr error
+	result := wait.Until[error](inputCtx, wait.Options{Timeout: timeout, Interval: interval}, func() []error {
+		if err := requests.DoHTTPRequestWithContext(inputCtx, url, method, headers, in.Body, status); err != nil {
+			if inputCtx.Err() == nil || lastErr == nil {
+				lastErr = err
+			}
+			return []error{err}
+		}
+		return nil
+	})
+	if result.OK {
+		return nil
+	}
+	if lastErr != nil {
+		return fmt.Errorf("retry exhausted after %d attempts: %w", result.Iterations, lastErr)
+	}
+	return fmt.Errorf("retry stopped after %d attempts: %w", result.Iterations, inputCtx.Err())
 }

--- a/runner/runner_test.go
+++ b/runner/runner_test.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync/atomic"
 	"testing"
 	"time"
 
@@ -1055,6 +1056,83 @@ func TestDoInputValidation(t *testing.T) {
 	if err := invalidStatus.doInput(context.Background(), casefile.Input{Path: "/health", Status: "created"}); err == nil || !strings.Contains(err.Error(), "not an integer") {
 		t.Fatalf("invalid status error = %v", err)
 	}
+}
+
+func TestDoInputDoesNotRetryByDefault(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	r, _ := newRunner(t, &stubExec{}, Options{Timeout: 100 * time.Millisecond, Interval: time.Millisecond})
+	setInputEndpoint(t, r, server.URL)
+	err := r.doInput(context.Background(), casefile.Input{Path: "/ready"})
+	if err == nil || !strings.Contains(err.Error(), "got: 503") {
+		t.Fatalf("doInput error = %v, want status mismatch", err)
+	}
+	if got := hits.Load(); got != 1 {
+		t.Fatalf("request count = %d, want 1", got)
+	}
+}
+
+func TestDoInputRetrySucceeds(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		if hits.Add(1) < 3 {
+			w.WriteHeader(http.StatusServiceUnavailable)
+			return
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	r, _ := newRunner(t, &stubExec{}, Options{Timeout: 100 * time.Millisecond, Interval: time.Millisecond})
+	setInputEndpoint(t, r, server.URL)
+	err := r.doInput(context.Background(), casefile.Input{Path: "/ready", Retry: &casefile.InputRetry{}})
+	if err != nil {
+		t.Fatalf("doInput: %v", err)
+	}
+	if got := hits.Load(); got != 3 {
+		t.Fatalf("request count = %d, want 3", got)
+	}
+}
+
+func TestDoInputRetryExhausted(t *testing.T) {
+	var hits atomic.Int32
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hits.Add(1)
+		w.WriteHeader(http.StatusServiceUnavailable)
+	}))
+	defer server.Close()
+
+	r, _ := newRunner(t, &stubExec{}, Options{})
+	setInputEndpoint(t, r, server.URL)
+	err := r.doInput(context.Background(), casefile.Input{
+		Path:  "/ready",
+		Retry: &casefile.InputRetry{Timeout: 50 * time.Millisecond, Interval: time.Millisecond},
+	})
+	if err == nil || !strings.Contains(err.Error(), "retry exhausted") || !strings.Contains(err.Error(), "got: 503") {
+		t.Fatalf("doInput error = %v, want exhausted status mismatch", err)
+	}
+	if got := hits.Load(); got < 2 {
+		t.Fatalf("request count = %d, want at least 2", got)
+	}
+}
+
+func setInputEndpoint(t *testing.T, r *Runner, serverURL string) {
+	t.Helper()
+	host, portText, err := net.SplitHostPort(strings.TrimPrefix(serverURL, "http://"))
+	if err != nil {
+		t.Fatalf("SplitHostPort: %v", err)
+	}
+	port, err := strconv.Atoi(portText)
+	if err != nil {
+		t.Fatalf("Atoi: %v", err)
+	}
+	r.endpoint.AppHost = host
+	r.endpoint.AppPort = port
 }
 
 func TestSeedCaseRejectsUnknownType(t *testing.T) {

--- a/testhelpers/requests/http.go
+++ b/testhelpers/requests/http.go
@@ -53,6 +53,12 @@ func DoHTTPRequestWithTimeout(url string, method string, headers map[string]stri
 	return doHTTPRequest(ctx, url, method, headers, payload, statusCode)
 }
 
+// DoHTTPRequestWithContext drives an application request until it completes or
+// the supplied context is cancelled.
+func DoHTTPRequestWithContext(ctx context.Context, url string, method string, headers map[string]string, payload string, statusCode int) error {
+	return doHTTPRequest(ctx, url, method, headers, payload, statusCode)
+}
+
 func doHTTPRequest(ctx context.Context, url string, method string, headers map[string]string, payload string, statusCode int) error {
 	var body io.Reader = nil
 


### PR DESCRIPTION
## Summary

- add per-HTTP-input opt-in retry configuration
- inherit the runner timeout and interval by default, with per-input overrides
- preserve one-shot behavior by default and document side-effect risks

## Testing

- `mise run check`
- `mise run build`