### PR TITLE
fix(release): ensure gcx updates trigger releases

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -11,5 +11,13 @@
   // **/examples/** (and tests, vendor, …). Disable it so example deps
   // (examples/python Dockerfile, requirements.txt) get tracked/updated.
   ignorePresets: [":ignoreModulesAndTests"],
+  packageRules: [
+    {
+      description: "Release OATs when the bundled gcx version changes",
+      matchDatasources: ["aqua"],
+      matchPackageNames: ["grafana/gcx"],
+      semanticCommitType: "fix",
+    },
+  ],
   automerge: true,
 }

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -14,7 +14,7 @@
   packageRules: [
     {
       description: "Release OATs when the bundled gcx version changes",
-      matchDatasources: ["aqua"],
+      matchDatasources: ["github-tags"],
       matchPackageNames: ["grafana/gcx"],
       semanticCommitType: "fix",
     },


### PR DESCRIPTION
## What changed

Configure Renovate to use `fix(deps):` for `aqua:grafana/gcx` updates.

## Why

The GCX v1.0.0 update in #452 used `chore(deps):`. Release Please does not treat that commit type as user-facing, so the release workflow skipped tag creation and GoReleaser did not publish binaries containing the updated bundled GCX version.

This fix is itself release-triggering, which unblocks the pending patch release, and future GCX updates will trigger releases automatically.

## Validation

- `mise run lint`
- push hook: `mise run lint:fix`
