### PR TITLE
chore: update renovate config

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -2,9 +2,9 @@
   $schema: "https://docs.renovatebot.com/renovate-schema.json",
   extends: [
     "config:best-practices",
-    "config:recommended",
     // Track `# renovate:`-annotated ENV pins in Dockerfiles (opentelemetry-distro).
     "customManagers:dockerfileVersions",
+    "helpers:pinGitHubActionDigestsToSemver",
     "github>grafana/flint#v0.22.10",
   ],
   // config:recommended pulls in :ignoreModulesAndTests, which ignores

--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -7,8 +7,8 @@
     "helpers:pinGitHubActionDigestsToSemver",
     "github>grafana/flint#v0.22.10",
   ],
-  // config:recommended pulls in :ignoreModulesAndTests, which ignores
-  // **/examples/** (and tests, vendor, …). Disable it so example deps
+  // config:best-practices pulls in :ignoreModulesAndTests, which ignores
+  // **/examples/** (and tests, vendor, ...). Disable it so example deps
   // (examples/python Dockerfile, requirements.txt) get tracked/updated.
   ignorePresets: [":ignoreModulesAndTests"],
   packageRules: [


### PR DESCRIPTION
- Add `helpers:pinGitHubActionDigestsToSemver` to ensure major upgrades always use a full version comment.
- Remove redundant `config:recommended` ([`config:best-practices`](https://docs.renovatebot.com/presets-config/#configbest-practices) extends it).
