### PR TITLE
docs: add security reporting guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -107,3 +107,4 @@ Key flags: `--config`, `--tags`, `--timeout`, `--interval`, `--absent-timeout`,
 - Lint on PRs (`mise run lint`), build on PRs (`mise run build`), tests on PRs (`mise run test`)
 - E2E tests in a separate workflow
 - Linting via flint
+- Security issues should be reported via [Grafana's security issue reporting page](https://grafana.com/legal/report-a-security-issue/) and not directly in this repository.


### PR DESCRIPTION
## What changed

- Added guidance to the repository's agent instructions directing security issues to Grafana's security reporting page instead of the repository.

## Why

This makes the expected reporting channel explicit for coding agents working in the repository.

## Validation

- `git diff --check`
- Confirmed the commit changes only one agent instruction file with one added line.
