### PR TITLE
ci: give PR title check a distinct status

### DIFF
--- a/.github/workflows/pr-title.yml
+++ b/.github/workflows/pr-title.yml
@@ -12,7 +12,7 @@ on:
 permissions: {}
 
 jobs:
-  lint:
+  pr-title:
     runs-on: ubuntu-24.04
     permissions:
       pull-requests: read


### PR DESCRIPTION
## Summary

- rename the PR title job from `lint` to `pr-title`
- avoid sharing a required-check context with the regular lint workflow

## Verification

- `mise run lint:fix`
- `mise run lint`

After this merges, add `pr-title` to the main branch ruleset's required status checks. Keeping that ruleset update until after merge avoids blocking existing pull requests whose base branch does not yet define the new context.
